### PR TITLE
Feature map custom overlay

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     },
     "dependencies": {
         "@radix-ui/react-dialog": "^1.1.4",
+        "@radix-ui/react-slot": "^1.1.2",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "lodash.debounce": "^4.0.8",
@@ -21,7 +22,9 @@
         "react-kakao-maps-sdk": "^1.1.27",
         "tailwind-merge": "^2.6.0",
         "tailwind-scrollbar-hide": "^2.0.0",
-        "tailwindcss-animate": "^1.0.7"
+        "tailwindcss-animate": "^1.0.7",
+        "vaul": "^1.1.2",
+        "zustand": "^5.0.3"
     },
     "devDependencies": {
         "@eslint/eslintrc": "^3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@radix-ui/react-dialog':
         specifier: ^1.1.4
         version: 1.1.4(@types/react-dom@19.0.3(@types/react@19.0.6))(@types/react@19.0.6)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-slot':
+        specifier: ^1.1.2
+        version: 1.1.2(@types/react@19.0.6)(react@19.0.0)
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -47,6 +50,12 @@ importers:
       tailwindcss-animate:
         specifier: ^1.0.7
         version: 1.0.7(tailwindcss@3.4.17)
+      vaul:
+        specifier: ^1.1.2
+        version: 1.1.2(@types/react-dom@19.0.3(@types/react@19.0.6))(@types/react@19.0.6)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      zustand:
+        specifier: ^5.0.3
+        version: 5.0.3(@types/react@19.0.6)(react@19.0.0)
     devDependencies:
       '@eslint/eslintrc':
         specifier: ^3
@@ -466,6 +475,15 @@ packages:
 
   '@radix-ui/react-slot@1.1.1':
     resolution: {integrity: sha512-RApLLOcINYJA+dMVbOju7MYv1Mb2EBp2nH4HdDzXTSyaR5optlm6Otrz1euW3HbdOR8UmmFK06TD+A9frYWv+g==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-slot@1.1.2':
+    resolution: {integrity: sha512-YAKxaiGsSQJ38VzKH86/BPRC4rh+b1Jpa+JneA5LRE7skmLPNAyeG8kPJj/oo4STLvlrs8vkf/iYyc3A5stYCQ==}
     peerDependencies:
       '@types/react': '*'
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
@@ -1936,6 +1954,12 @@ packages:
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
+  vaul@1.1.2:
+    resolution: {integrity: sha512-ZFkClGpWyI2WUQjdLJ/BaGuV6AVQiJ3uELGk3OYtP+B6yCO7Cmn9vPFXVJkRaGkOJu3m8bQMgtyzNHixULceQA==}
+    peerDependencies:
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc
+
   which-boxed-primitive@1.1.1:
     resolution: {integrity: sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==}
     engines: {node: '>= 0.4'}
@@ -1977,6 +2001,24 @@ packages:
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+
+  zustand@5.0.3:
+    resolution: {integrity: sha512-14fwWQtU3pH4dE0dOpdMiWjddcH+QzKIgk1cl8epwSE7yag43k/AD/m4L6+K7DytAOr9gGBe3/EXj9g7cdostg==}
+    engines: {node: '>=12.20.0'}
+    peerDependencies:
+      '@types/react': '>=18.0.0'
+      immer: '>=9.0.6'
+      react: '>=18.0.0'
+      use-sync-external-store: '>=1.2.0'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      immer:
+        optional: true
+      react:
+        optional: true
+      use-sync-external-store:
+        optional: true
 
 snapshots:
 
@@ -2297,6 +2339,13 @@ snapshots:
       '@types/react-dom': 19.0.3(@types/react@19.0.6)
 
   '@radix-ui/react-slot@1.1.1(@types/react@19.0.6)(react@19.0.0)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.1(@types/react@19.0.6)(react@19.0.0)
+      react: 19.0.0
+    optionalDependencies:
+      '@types/react': 19.0.6
+
+  '@radix-ui/react-slot@1.1.2(@types/react@19.0.6)(react@19.0.0)':
     dependencies:
       '@radix-ui/react-compose-refs': 1.1.1(@types/react@19.0.6)(react@19.0.0)
       react: 19.0.0
@@ -4050,6 +4099,15 @@ snapshots:
 
   util-deprecate@1.0.2: {}
 
+  vaul@1.1.2(@types/react-dom@19.0.3(@types/react@19.0.6))(@types/react@19.0.6)(react-dom@19.0.0(react@19.0.0))(react@19.0.0):
+    dependencies:
+      '@radix-ui/react-dialog': 1.1.4(@types/react-dom@19.0.3(@types/react@19.0.6))(@types/react@19.0.6)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
+
   which-boxed-primitive@1.1.1:
     dependencies:
       is-bigint: 1.1.0
@@ -4111,3 +4169,8 @@ snapshots:
   yaml@2.7.0: {}
 
   yocto-queue@0.1.0: {}
+
+  zustand@5.0.3(@types/react@19.0.6)(react@19.0.0):
+    optionalDependencies:
+      '@types/react': 19.0.6
+      react: 19.0.0

--- a/src/app/(with-hamburger-button)/layout.tsx
+++ b/src/app/(with-hamburger-button)/layout.tsx
@@ -5,7 +5,6 @@ import { ReactNode } from 'react';
 export default function Layout({ children }: { children: ReactNode }) {
     return (
         <div>
-            <KakaoLogin />
             <ProtestList />
             {children}
         </div>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -3,7 +3,7 @@
 @tailwind utilities;
 
 * {
-    box-sizing: bordser-box;
+    box-sizing: border-box;
     margin: 0;
 }
 

--- a/src/app/protest/[id]/page.tsx
+++ b/src/app/protest/[id]/page.tsx
@@ -36,12 +36,12 @@ export default async function Page({ params }: { params: Promise<{ id: string }>
 
     return (
         <section className="bg-zinc-100 h-[100dvh] w-full min-w-[260px]">
-            <div className="flex bg-background-white">
-                <div className="flex flex-col gap-0.1 py-3 bg-background-white w-[80%]">
+            <div className="flex justify-center bg-background-white w-[100%]">
+                <div className="flex flex-col gap-0.1 py-3 bg-background-white">
                     <h1 className="text-[#D44646] w-[85%] min-w-[240px] mx-auto font-bold">{title}</h1>
                     <span className="text-zinc-400 w-[85%] min-w-[240px] mx-auto  text-sm">{location}</span>
                 </div>
-                <div className="w-[20%]">
+                <div className="flex justify-center items-center">
                     <Verification paramId={paramId} />
                 </div>
             </div>

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -1,6 +1,7 @@
 import Link from 'next/link';
 import { Single_Day } from 'next/font/google';
 import styles from './Header.module.css'; // ✅ CSS 모듈 불러오기
+import KakaoLogin from '../KakaoLogin/KakaoLogin';
 
 const singleDay = Single_Day({ weight: '400' });
 
@@ -13,6 +14,7 @@ export default function Header() {
                 <span className={styles.normalText}>시</span>
                 <span className={styles.smallText}>위</span> <span className={styles.smallText}>Now</span>
             </Link>
+            <KakaoLogin />
         </header>
     );
 }

--- a/src/components/KakaoLogin/KakaoLogin.tsx
+++ b/src/components/KakaoLogin/KakaoLogin.tsx
@@ -1,6 +1,10 @@
 'use client';
 
+import useUserInfo from '@/hooks/useUserInfo';
+
 export default function KakaoLogin() {
+    const { userInfo } = useUserInfo();
+
     const onLoginClick = async () => {
         const previous_page = window.location.href;
         localStorage.setItem('previous_page', previous_page);
@@ -11,10 +15,16 @@ export default function KakaoLogin() {
     };
 
     return (
-        <div className="absolute bottom-0 right-0 z-50">
-            <button onClick={onLoginClick} className="p-5 bg-yellow-500">
-                login
-            </button>
+        <div className="absolute top-0 right-0 z-50">
+            {userInfo ? (
+                <button onClick={onLoginClick} className="p-2 text-[#D44646]">
+                    login
+                </button>
+            ) : (
+                <button onClick={onLoginClick} className="p-2 text-[#D44646]">
+                    logout
+                </button>
+            )}
         </div>
     );
 }

--- a/src/components/KakaoMaps/KakaoMap.tsx
+++ b/src/components/KakaoMaps/KakaoMap.tsx
@@ -1,10 +1,11 @@
 'use client';
 
-import { Map, MapMarker, MapTypeControl, ZoomControl } from 'react-kakao-maps-sdk';
+import { CustomOverlayMap, Map, MapMarker, MapTypeControl, ZoomControl } from 'react-kakao-maps-sdk';
 import useKakaoLoader from '@/hooks/useKakaoLoader';
 import { useEffect, useState, useCallback, useRef } from 'react';
 import { useRouter } from 'next/navigation';
 import { ProtestData } from '@/types';
+import VerificationBadge from '../Protest/verification-badge';
 
 export default function KakaoMap({
     latitude,
@@ -101,8 +102,8 @@ export default function KakaoMap({
 
             const heatmap = (window as any).h337.create({
                 container,
-                maxOpacity: 0.6,
-                minOpacity: 0.2,
+                maxOpacity: 0.4,
+                minOpacity: 0.1,
                 blur: 0.95,
             });
 
@@ -165,6 +166,15 @@ export default function KakaoMap({
             >
                 {protests.map((protest) => (
                     <div key={protest.id}>
+                        <CustomOverlayMap
+                            position={{
+                                lat: protest.locations[0].latitude,
+                                lng: protest.locations[0].longitude,
+                            }}
+                            yAnchor={3}
+                        >
+                            <VerificationBadge protestId={protest.id} />
+                        </CustomOverlayMap>
                         <MapMarker
                             position={{
                                 lat: protest.locations[0].latitude,
@@ -185,6 +195,7 @@ export default function KakaoMap({
                         />
                     </div>
                 ))}
+
                 <MapTypeControl position={'TOPLEFT'} />
                 <ZoomControl position={'LEFT'} />
             </Map>

--- a/src/components/Login/Login.tsx
+++ b/src/components/Login/Login.tsx
@@ -2,10 +2,12 @@
 
 import { useEffect } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
+import useUserInfo from '@/hooks/useUserInfo';
 
 export default function Login() {
     const router = useRouter();
     const searchParams = useSearchParams();
+    const { setUserInfo } = useUserInfo();
 
     useEffect(() => {
         const previous_page = localStorage.getItem('previous_page');
@@ -13,6 +15,7 @@ export default function Login() {
 
         if (accessToken) {
             localStorage.setItem('access_token', accessToken);
+            setUserInfo({ accessToken });
             router.replace(previous_page!);
         } else {
             console.error('Access token not found');

--- a/src/components/Protest/verification-badge.tsx
+++ b/src/components/Protest/verification-badge.tsx
@@ -1,0 +1,28 @@
+import { Badge } from '@/components/ui/badge';
+import VerificationNumber from '@/lib/API/VerificationNumber';
+import { useEffect, useState } from 'react';
+import { IoPerson } from 'react-icons/io5';
+
+export default function VerificationBadge({ protestId }: { protestId: string }) {
+    const [verifiedNumber, setVerifiedNumber] = useState(0);
+
+    useEffect(() => {
+        const verifyNumber = async () => {
+            const result = await VerificationNumber({
+                protestId: protestId,
+                date: '2025-03-15',
+            });
+            setVerifiedNumber(result.verifiedNum);
+        };
+        verifyNumber();
+    }, []);
+
+    return (
+        <div className="flex gap-1 text-[#D44646] items-center">
+            <IoPerson />
+            <Badge variant={'destructive'} className="">
+                {verifiedNumber}
+            </Badge>
+        </div>
+    );
+}

--- a/src/components/Verification/Verification.tsx
+++ b/src/components/Verification/Verification.tsx
@@ -2,7 +2,18 @@
 
 import { useGeoLocation } from '@/hooks/useGeoLocation';
 import VerifyLocation from '@/lib/API/VerifyLocation';
+import { Button } from '@/components/ui/button';
+import { Loader2 } from 'lucide-react';
 import { useEffect, useState } from 'react';
+import {
+    Drawer,
+    DrawerClose,
+    DrawerContent,
+    DrawerDescription,
+    DrawerFooter,
+    DrawerHeader,
+    DrawerTitle,
+} from '@/components/ui/drawer';
 
 interface VerificationResult {
     success: boolean;
@@ -11,11 +22,17 @@ interface VerificationResult {
 
 export default function Verification({ paramId }: { paramId: string }) {
     const [agreed, setAgreed] = useState(false);
+    const [open, setOpen] = useState(false);
     const [verificationResult, setVerificationResult] = useState<VerificationResult | null>(null);
     const { curLocation, isLoading, errorMsg } = useGeoLocation(agreed);
+
     const onVerificationClick = () => {
-        console.log('동의한대');
+        setOpen(true);
+    };
+
+    const handleAgree = () => {
         setAgreed(true);
+        setOpen(false);
     };
 
     useEffect(() => {
@@ -32,19 +49,34 @@ export default function Verification({ paramId }: { paramId: string }) {
         verifyUserLocation();
     }, [agreed, curLocation]);
 
-    if (agreed && isLoading) {
-        return <div>Loading...</div>;
-    }
-
     if (agreed && errorMsg) {
         return <div>{errorMsg}</div>;
     }
 
-    console.log(verificationResult);
-
     return (
         <div>
-            <button onClick={onVerificationClick}>인증하기</button>
+            <Button variant={'signature'} size={'sm'} onClick={onVerificationClick}>
+                {isLoading ? <Loader2 className="animate-spin" /> : <div>인증하기</div>}
+            </Button>
+            <Drawer open={open} onOpenChange={setOpen}>
+                {open && (
+                    <DrawerContent>
+                        <DrawerHeader>
+                            <DrawerTitle>위치동의 drawer</DrawerTitle>
+                            <DrawerDescription>위치 인증 동의 여부를 묻습니다</DrawerDescription>
+                        </DrawerHeader>
+                        <div className="p-4 flex justify-center gap-4">
+                            <Button variant={'signature'} onClick={handleAgree}>
+                                동의
+                            </Button>
+                            <DrawerClose asChild>
+                                <Button variant="outline">취소</Button>
+                            </DrawerClose>
+                        </div>
+                        <DrawerFooter className="hidden">footer</DrawerFooter>
+                    </DrawerContent>
+                )}
+            </Drawer>
         </div>
     );
 }

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -1,0 +1,36 @@
+import * as React from "react"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+const badgeVariants = cva(
+  "inline-flex items-center rounded-md border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2",
+  {
+    variants: {
+      variant: {
+        default:
+          "border-transparent bg-primary text-primary-foreground shadow hover:bg-primary/80",
+        secondary:
+          "border-transparent bg-secondary text-secondary-foreground hover:bg-secondary/80",
+        destructive:
+          "border-transparent bg-destructive text-destructive-foreground shadow hover:bg-destructive/80",
+        outline: "text-foreground",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)
+
+export interface BadgeProps
+  extends React.HTMLAttributes<HTMLDivElement>,
+    VariantProps<typeof badgeVariants> {}
+
+function Badge({ className, variant, ...props }: BadgeProps) {
+  return (
+    <div className={cn(badgeVariants({ variant }), className)} {...props} />
+  )
+}
+
+export { Badge, badgeVariants }

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,0 +1,48 @@
+import * as React from 'react';
+import { Slot } from '@radix-ui/react-slot';
+import { cva, type VariantProps } from 'class-variance-authority';
+
+import { cn } from '@/lib/utils';
+
+const buttonVariants = cva(
+    'inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0',
+    {
+        variants: {
+            variant: {
+                default: 'bg-primary text-primary-foreground shadow hover:bg-primary/90',
+                destructive: 'bg-destructive text-destructive-foreground shadow-sm hover:bg-destructive/90',
+                outline: 'border border-input bg-background shadow-sm hover:bg-accent hover:text-accent-foreground',
+                secondary: 'bg-secondary text-secondary-foreground shadow-sm hover:bg-secondary/80',
+                ghost: 'hover:bg-accent hover:text-accent-foreground',
+                signature: 'bg-[#D44646] text-white shadow-sm hover:bg-destructive/90',
+                link: 'text-primary underline-offset-4 hover:underline',
+            },
+            size: {
+                default: 'h-9 px-4 py-2',
+                sm: 'h-8 rounded-md px-3 text-xs',
+                lg: 'h-10 rounded-md px-8',
+                icon: 'h-9 w-9',
+            },
+        },
+        defaultVariants: {
+            variant: 'default',
+            size: 'default',
+        },
+    }
+);
+
+export interface ButtonProps
+    extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+        VariantProps<typeof buttonVariants> {
+    asChild?: boolean;
+}
+
+const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+    ({ className, variant, size, asChild = false, ...props }, ref) => {
+        const Comp = asChild ? Slot : 'button';
+        return <Comp className={cn(buttonVariants({ variant, size, className }))} ref={ref} {...props} />;
+    }
+);
+Button.displayName = 'Button';
+
+export { Button, buttonVariants };

--- a/src/components/ui/drawer.tsx
+++ b/src/components/ui/drawer.tsx
@@ -1,0 +1,118 @@
+"use client"
+
+import * as React from "react"
+import { Drawer as DrawerPrimitive } from "vaul"
+
+import { cn } from "@/lib/utils"
+
+const Drawer = ({
+  shouldScaleBackground = true,
+  ...props
+}: React.ComponentProps<typeof DrawerPrimitive.Root>) => (
+  <DrawerPrimitive.Root
+    shouldScaleBackground={shouldScaleBackground}
+    {...props}
+  />
+)
+Drawer.displayName = "Drawer"
+
+const DrawerTrigger = DrawerPrimitive.Trigger
+
+const DrawerPortal = DrawerPrimitive.Portal
+
+const DrawerClose = DrawerPrimitive.Close
+
+const DrawerOverlay = React.forwardRef<
+  React.ElementRef<typeof DrawerPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof DrawerPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <DrawerPrimitive.Overlay
+    ref={ref}
+    className={cn("fixed inset-0 z-50 bg-black/80", className)}
+    {...props}
+  />
+))
+DrawerOverlay.displayName = DrawerPrimitive.Overlay.displayName
+
+const DrawerContent = React.forwardRef<
+  React.ElementRef<typeof DrawerPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DrawerPrimitive.Content>
+>(({ className, children, ...props }, ref) => (
+  <DrawerPortal>
+    <DrawerOverlay />
+    <DrawerPrimitive.Content
+      ref={ref}
+      className={cn(
+        "fixed inset-x-0 bottom-0 z-50 mt-24 flex h-auto flex-col rounded-t-[10px] border bg-background",
+        className
+      )}
+      {...props}
+    >
+      <div className="mx-auto mt-4 h-2 w-[100px] rounded-full bg-muted" />
+      {children}
+    </DrawerPrimitive.Content>
+  </DrawerPortal>
+))
+DrawerContent.displayName = "DrawerContent"
+
+const DrawerHeader = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn("grid gap-1.5 p-4 text-center sm:text-left", className)}
+    {...props}
+  />
+)
+DrawerHeader.displayName = "DrawerHeader"
+
+const DrawerFooter = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn("mt-auto flex flex-col gap-2 p-4", className)}
+    {...props}
+  />
+)
+DrawerFooter.displayName = "DrawerFooter"
+
+const DrawerTitle = React.forwardRef<
+  React.ElementRef<typeof DrawerPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof DrawerPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <DrawerPrimitive.Title
+    ref={ref}
+    className={cn(
+      "text-lg font-semibold leading-none tracking-tight",
+      className
+    )}
+    {...props}
+  />
+))
+DrawerTitle.displayName = DrawerPrimitive.Title.displayName
+
+const DrawerDescription = React.forwardRef<
+  React.ElementRef<typeof DrawerPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof DrawerPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <DrawerPrimitive.Description
+    ref={ref}
+    className={cn("text-sm text-muted-foreground", className)}
+    {...props}
+  />
+))
+DrawerDescription.displayName = DrawerPrimitive.Description.displayName
+
+export {
+  Drawer,
+  DrawerPortal,
+  DrawerOverlay,
+  DrawerTrigger,
+  DrawerClose,
+  DrawerContent,
+  DrawerHeader,
+  DrawerFooter,
+  DrawerTitle,
+  DrawerDescription,
+}

--- a/src/hooks/useUserInfo.ts
+++ b/src/hooks/useUserInfo.ts
@@ -1,0 +1,28 @@
+import { create } from 'zustand';
+
+interface userInfoType {
+    accessToken: string;
+}
+
+interface UserInfoState {
+    userInfo: userInfoType;
+}
+
+interface UserInfoActions {
+    setUserInfo: (userinfo: userInfoType) => void;
+    deleteUserInfo: () => void;
+}
+
+const defaultState = { accessToken: '' };
+
+const useUserInfo = create<UserInfoState & UserInfoActions>((set) => ({
+    userInfo: defaultState,
+    setUserInfo: (userInfo: userInfoType) => {
+        set({ userInfo });
+    },
+    deleteUserInfo: () => {
+        set({ userInfo: defaultState });
+    },
+}));
+
+export default useUserInfo;

--- a/src/lib/API/VerificationNumber.tsx
+++ b/src/lib/API/VerificationNumber.tsx
@@ -1,0 +1,19 @@
+import { notFound } from 'next/navigation';
+
+export default async function VerificationNumber({ protestId, date }: { protestId: string; date: string }) {
+    const SERVER_URL = process.env.NEXT_PUBLIC_SERVER_DEV_URL;
+    const response = await fetch(`${SERVER_URL}/api/protest/verifications?protestId=${protestId}&date=${date}`, {
+        cache: 'no-store',
+    });
+
+    if (!response.ok) {
+        if (response.status === 404) {
+            notFound();
+        }
+        return <div>오류가 발생했습니다...</div>;
+    }
+
+    const protests = await response.json();
+
+    return protests.data[0];
+}

--- a/src/lib/API/VerifyLocation.tsx
+++ b/src/lib/API/VerifyLocation.tsx
@@ -19,6 +19,7 @@ export default async function VerifyLocation({
             body: JSON.stringify({ longitude, latitude }),
         });
         if (!response.ok) {
+            console.log(response);
             throw new Error('서버 요청 실패');
         }
         const verification = await response.json();


### PR DESCRIPTION
## 📝작업 내용

유저의 시위참여 인증, 로그인 로직, 인증 수 뱃지

- 유저는 시위참여 인증 버튼을 통해 열리는 drawer을 통해 위치 정보 이용 동의를 하고서 인증을 한다.
- 기존에 로컬스토리지에서 관리하던 accesstoken은 zustand를 통해 관리한다.
- 인증 수 뱃지는 지도에서 각 마커 상단에 위치하며, 일단 캐싱은 하지 않는다.

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.
