### PR TITLE
Feature seo

### DIFF
--- a/next-sitemap.config.ts
+++ b/next-sitemap.config.ts
@@ -1,0 +1,47 @@
+import type { IConfig, ISitemapField } from 'next-sitemap';
+
+const config: IConfig = {
+    siteUrl: process.env.NEXT_PUBLIC_SERVER_DEV_URL || 'https://eye-on.kr/',
+    generateRobotsTxt: true,
+    sitemapSize: 5000,
+    exclude: ['/oauth2/*'],
+    additionalPaths: async (config) => {
+        const date = new Date().toISOString().split('T')[0];
+        const SERVER_URL = process.env.NEXT_PUBLIC_SERVER_DEV_URL;
+
+        try {
+            const response = await fetch(`${SERVER_URL}/api/protest?date=${date}`, {
+                next: { revalidate: 3600 },
+            });
+
+            if (!response.ok) {
+                throw new Error('Failed to fetch protest data');
+            }
+
+            const protestsData = await response.json();
+            const protests = protestsData.data;
+
+            const paths: ISitemapField[] = [
+                {
+                    loc: '/',
+                    lastmod: new Date().toISOString(),
+                    changefreq: 'daily' as const,
+                    priority: 1.0,
+                },
+                ...protests.map((protest: any) => ({
+                    loc: `/protests/${protest.id}`,
+                    lastmod: new Date().toISOString(),
+                    changefreq: 'daily' as const,
+                    priority: 0.7,
+                })),
+            ];
+
+            return paths;
+        } catch (error) {
+            console.error('Error generating sitemap:', error);
+            return [];
+        }
+    },
+};
+
+export default config;

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
         "dev": "next dev",
         "build": "next build",
         "start": "next start",
-        "lint": "next lint"
+        "lint": "next lint",
+        "postbuild": "next-sitemap --config next-sitemap.config.ts"
     },
     "dependencies": {
         "@radix-ui/react-dialog": "^1.1.4",
@@ -16,6 +17,7 @@
         "lodash.debounce": "^4.0.8",
         "lucide-react": "^0.471.0",
         "next": "15.1.4",
+        "next-sitemap": "^4.2.3",
         "next-themes": "^0.4.4",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       next:
         specifier: 15.1.4
         version: 15.1.4(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      next-sitemap:
+        specifier: ^4.2.3
+        version: 4.2.3(next@15.1.4(react-dom@19.0.0(react@19.0.0))(react@19.0.0))
       next-themes:
         specifier: ^0.4.4
         version: 0.4.4(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
@@ -103,6 +106,9 @@ packages:
   '@babel/runtime@7.26.0':
     resolution: {integrity: sha512-FDSOghenHTiToteC/QRlv2q3DhPZ/oOXTBoirfWNx1Cx3TMVcGWQtMMmQcSvb/JjpNeGzx8Pq/b4fKEJuWm1sw==}
     engines: {node: '>=6.9.0'}
+
+  '@corex/deepmerge@4.0.43':
+    resolution: {integrity: sha512-N8uEMrMPL0cu/bdboEWpQYb/0i2K5Qn8eCsxzOmxSggJbbQte7ljMRoXm917AbntqTGOzdTu+vP3KOOzoC70HQ==}
 
   '@emnapi/runtime@1.3.1':
     resolution: {integrity: sha512-kEBmG8KyqtxJZv+ygbEim+KCGtIq1fC22Ms3S4ziXmYKm8uyoLX0MHONVKwp+9opg390VaKRNt4a7A9NwmpNhw==}
@@ -287,6 +293,9 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.25':
     resolution: {integrity: sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==}
+
+  '@next/env@13.5.8':
+    resolution: {integrity: sha512-YmiG58BqyZ2FjrF2+5uZExL2BrLr8RTQzLXNDJ8pJr0O+rPlOeDPXp1p1/4OrR3avDidzZo3D8QO2cuDv1KCkw==}
 
   '@next/env@15.1.4':
     resolution: {integrity: sha512-2fZ5YZjedi5AGaeoaC0B20zGntEHRhi2SdWcu61i48BllODcAmmtj8n7YarSPt4DaTsJaBFdxQAVEVzgmx2Zpw==}
@@ -1428,6 +1437,13 @@ packages:
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
+  next-sitemap@4.2.3:
+    resolution: {integrity: sha512-vjdCxeDuWDzldhCnyFCQipw5bfpl4HmZA7uoo3GAaYGjGgfL4Cxb1CiztPuWGmS+auYs7/8OekRS8C2cjdAsjQ==}
+    engines: {node: '>=14.18'}
+    hasBin: true
+    peerDependencies:
+      next: '*'
+
   next-themes@0.4.4:
     resolution: {integrity: sha512-LDQ2qIOJF0VnuVrrMSMLrWGjRMkq+0mpgl6e0juCLqdJ+oo8Q84JRWT6Wh11VDQKkMMe+dVzDKLWs5n87T+PkQ==}
     peerDependencies:
@@ -2046,6 +2062,8 @@ snapshots:
     dependencies:
       regenerator-runtime: 0.14.1
 
+  '@corex/deepmerge@4.0.43': {}
+
   '@emnapi/runtime@1.3.1':
     dependencies:
       tslib: 2.8.1
@@ -2206,6 +2224,8 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.0
+
+  '@next/env@13.5.8': {}
 
   '@next/env@15.1.4': {}
 
@@ -3491,6 +3511,14 @@ snapshots:
   nanoid@3.3.8: {}
 
   natural-compare@1.4.0: {}
+
+  next-sitemap@4.2.3(next@15.1.4(react-dom@19.0.0(react@19.0.0))(react@19.0.0)):
+    dependencies:
+      '@corex/deepmerge': 4.0.43
+      '@next/env': 13.5.8
+      fast-glob: 3.3.3
+      minimist: 1.2.8
+      next: 15.1.4(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
 
   next-themes@0.4.4(react-dom@19.0.0(react@19.0.0))(react@19.0.0):
     dependencies:


### PR DESCRIPTION
sitemap 생성 로직 작성

next-sitemap을 이용해 빌드 시 자동으로 sitemap과 robot을 생성함.
시위 상세정보 페이지는 동적 경로를 가지기 때문에 별도로 상세정보 get API를 호출하여 미리 생성되는 모든 정적 페이지들에 대해 sitemap이 생성될 수 있도록 추가하였음.
로그인 리다이렉트용으로 사용하고 있는 페이지는 제외할 수 있도록 하였음.