### PR TITLE
[FE] feat : add is mobile advice logic when verification excute

### DIFF
--- a/src/components/Verification/Verification.tsx
+++ b/src/components/Verification/Verification.tsx
@@ -17,6 +17,7 @@ import {
 import useUserInfo from '@/hooks/useUserInfo';
 import { toast } from 'sonner';
 import { VerificationResponse } from '@/lib/API/VerifyLocation';
+import { getIsMobile, isDesktopOS } from '@/lib/utils';
 
 export default function Verification({ paramId }: { paramId: string }) {
     const [agreed, setAgreed] = useState(false);
@@ -24,7 +25,12 @@ export default function Verification({ paramId }: { paramId: string }) {
     const [verificationResult, setVerificationResult] = useState<VerificationResponse | null>(null);
     const { curLocation, isLoading, errorMsg } = useGeoLocation(agreed);
     const accessToken = useUserInfo((state) => state.userInfo.accessToken);
+    const isMobile = getIsMobile() && !isDesktopOS();
     const onVerificationClick = () => {
+        if (!isMobile) {
+            alert('모바일에서만 인증이 가능합니다.');
+            return;
+        }
         if (!accessToken)
             window.location.replace(`${process.env.NEXT_PUBLIC_LOCAL_DEV_URL}/oauth2/authorization/kakao`);
         else setOpen(true);

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -18,3 +18,18 @@ export const formatDate = (isoString: string) => {
 
     return `${month}월 ${day}일 ${weekday} ${hours}시 ${minutes}분 `;
 };
+
+export const isDesktopOS = () => {
+    return (
+        'win16|win32|win64|windows|mac|macintel|linux|freebsd|openbsd|sunos'.indexOf(
+            navigator.platform.toLowerCase()
+        ) >= 0
+    );
+};
+
+export const getIsMobile = () => {
+    const userAgent = window.navigator.userAgent;
+    const isMobile =
+        /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(userAgent);
+    return isMobile;
+};


### PR DESCRIPTION
## #️⃣연관된 이슈
- #18 
## 📝작업 내용
- 처음에는 getIsMobile 함수만을 통해서 유저 에이전트 값에 모바일이 있는지만 체크했습니다.
- 하지만 그리하면 크롭 개발자도구에서 모바일 디바이스 적용 후 인증하기를 클릭하면 유저 에이전트에 설정한 모바일 디바이스가 찍혀있어서 인증하기 버튼이 클릭이 되버립니다.
- 하지만 유저 에이전트에 접속하고 있는 데스크탑 정보도 같이 있기에 데스크탑인지 판별 로직도 추가하여 그 문제를 해결하였습니다.
변경 전
```
const onVerificationClick = () => {
    if (!accessToken)
        window.location.replace(`${process.env.NEXT_PUBLIC_LOCAL_DEV_URL}/oauth2/authorization/kakao`);
    else setOpen(true);
};
```
변경 후
```
const isMobile = getIsMobile() && !isDesktopOS();
const onVerificationClick = () => {
    if (!isMobile) {
        alert('모바일에서만 인증이 가능합니다.');
        return;
    }
    if (!accessToken)
        window.location.replace(`${process.env.NEXT_PUBLIC_LOCAL_DEV_URL}/oauth2/authorization/kakao`);
    else setOpen(true);
};
export const isDesktopOS = () => {
    return (
        'win16|win32|win64|windows|mac|macintel|linux|freebsd|openbsd|sunos'.indexOf(
            navigator.platform.toLowerCase()
        ) >= 0
    );
};

export const getIsMobile = () => {
    const userAgent = window.navigator.userAgent;
    const isMobile =
        /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(userAgent);
    return isMobile;
};

```

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.
