### PR TITLE
refactor: fixed parellel routing issue

### DIFF
--- a/src/components/KakaoLogin/KakaoLogin.tsx
+++ b/src/components/KakaoLogin/KakaoLogin.tsx
@@ -10,7 +10,10 @@ export default function KakaoLogin() {
 
     const onLoginClick = async () => {
         const previous_page = window.location.href;
-        localStorage.setItem('previous_page', previous_page);
+
+        if (!previous_page.includes('oauth2/callback')) {
+            localStorage.setItem('previous_page', previous_page);
+        }
 
         const LOCAL_DEV_URL = process.env.NEXT_PUBLIC_LOCAL_DEV_URL;
 
@@ -23,13 +26,13 @@ export default function KakaoLogin() {
     };
 
     return (
-        <div className='absolute top-2 right-0 z-50'>
+        <div className="absolute top-2 right-0 z-50">
             {accessToken === '' ? (
-                <button onClick={onLoginClick} className='p-2 text-[#D44646]'>
+                <button onClick={onLoginClick} className="p-2 text-[#D44646]">
                     login
                 </button>
             ) : (
-                <button onClick={onLogoutClick} className='p-2 text-[#D44646]'>
+                <button onClick={onLogoutClick} className="p-2 text-[#D44646]">
                     logout
                 </button>
             )}

--- a/src/components/Login/Login.tsx
+++ b/src/components/Login/Login.tsx
@@ -15,6 +15,7 @@ export default function Login() {
 
         if (accessToken) {
             setUserInfo({ accessToken });
+            router.replace('/');
             router.replace(previous_page!);
         } else {
             console.error('Access token not found');


### PR DESCRIPTION
## 📝작업 내용

- when logged in from protest detail page, modal's background shows login component
- prevented by not setting previous page if login route
- sends to index page before returning to previous page
