### PR TITLE
Feature protest route

### DIFF
--- a/src/app/(with-hamburger-button)/page.tsx
+++ b/src/app/(with-hamburger-button)/page.tsx
@@ -42,12 +42,12 @@ export default async function Home() {
     const latitude = 37.539581447331;
     const longitude = 127.00787604008;
     return (
-        <div>
+        <div className="relative">
             <KakaoMap
                 latitude={latitude}
                 longitude={longitude}
-                w='100%'
-                h='calc(100dvh - 14vh)'
+                w="100%"
+                h="calc(100dvh - 14vh)"
                 l={8}
                 protests={protests}
             />

--- a/src/app/api/directions/route/route.ts
+++ b/src/app/api/directions/route/route.ts
@@ -1,0 +1,32 @@
+import { NextResponse } from 'next/server';
+
+export async function GET(req: Request) {
+    const { searchParams } = new URL(req.url);
+    const start = searchParams.get('start');
+    const goal = searchParams.get('goal');
+    const waypoints = searchParams.get('waypoints');
+
+    if (!start || !goal) {
+        return NextResponse.json({ error: '출발지와 목적지는 필수입니다.' }, { status: 400 });
+    }
+
+    const apiUrl = `https://naveropenapi.apigw.ntruss.com/map-direction/v1/driving?start=${start}&goal=${goal}&waypoints=${
+        waypoints || ''
+    }&option=trafast`;
+
+    const response = await fetch(apiUrl, {
+        headers: {
+            'X-NCP-APIGW-API-KEY-ID': process.env.NEXT_PUBLIC_NAVER_CLIENT_ID || '',
+            'X-NCP-APIGW-API-KEY': process.env.NEXT_PUBLIC_NAVER_CLIENT_SECRET || '',
+        },
+        cache: 'force-cache',
+        next: { revalidate: 3600 },
+    });
+
+    if (!response.ok) {
+        return NextResponse.json({ error: '경로 검색 실패' }, { status: response.status });
+    }
+
+    const data = await response.json();
+    return NextResponse.json(data);
+}

--- a/src/components/KakaoMaps/KakaoMap.tsx
+++ b/src/components/KakaoMaps/KakaoMap.tsx
@@ -39,6 +39,7 @@ export default function KakaoMap({
     const [agreed, setAgreed] = useState(false);
     const [buttonClicked, setButtonClicked] = useState(false);
     const [typeOfButton, setTypeOfButton] = useState('');
+    const [currentPositionMarker, setCurrentPositionMarker] = useState(false);
     const router = useRouter();
     const animationFrameRef = useRef<number | null>(null);
     const isUpdatingRef = useRef(false);
@@ -68,12 +69,14 @@ export default function KakaoMap({
         if (!isLoading && curLocation && mapInstance) {
             if (typeOfButton === 'gps') {
                 const destLatLng = new kakao.maps.LatLng(curLocation.latitude, curLocation.longitude);
-
+                setCurrentPositionMarker(true);
+                mapInstance.setLevel(2);
                 mapInstance.panTo(destLatLng);
                 setAgreed(false);
                 setButtonClicked(false);
             } else {
                 const destLatLng = new kakao.maps.LatLng(37.539581447331, 127.00787604008);
+                setCurrentPositionMarker(false);
                 mapInstance.setLevel(7);
                 mapInstance.panTo(destLatLng);
                 setButtonClicked(false);
@@ -311,6 +314,10 @@ export default function KakaoMap({
                           />
                       ))
                     : null}
+
+                {currentPositionMarker ? (
+                    <MapMarker position={{ lat: curLocation!.latitude, lng: curLocation!.longitude }} />
+                ) : null}
 
                 <MapTypeControl position={'TOPLEFT'} />
                 <ZoomControl position={'LEFT'} />

--- a/src/components/KakaoMaps/KakaoMap.tsx
+++ b/src/components/KakaoMaps/KakaoMap.tsx
@@ -61,8 +61,6 @@ export default function KakaoMap({
             } else {
                 setTypeOfButton('reset');
             }
-            const destLatLng = new kakao.maps.LatLng(latitude, longitude);
-            mapInstance.panTo(destLatLng);
         }
     };
 
@@ -70,11 +68,13 @@ export default function KakaoMap({
         if (!isLoading && curLocation && mapInstance) {
             if (typeOfButton === 'gps') {
                 const destLatLng = new kakao.maps.LatLng(curLocation.latitude, curLocation.longitude);
+
                 mapInstance.panTo(destLatLng);
                 setAgreed(false);
                 setButtonClicked(false);
             } else {
                 const destLatLng = new kakao.maps.LatLng(37.539581447331, 127.00787604008);
+                mapInstance.setLevel(7);
                 mapInstance.panTo(destLatLng);
                 setButtonClicked(false);
             }
@@ -217,11 +217,11 @@ export default function KakaoMap({
                     const goal = `${locations[locations.length - 1].longitude},${
                         locations[locations.length - 1].latitude
                     }`;
+
                     const waypoints =
-                        locations
-                            .slice(1, -1)
-                            .map((loc) => `${loc.longitude},${loc.latitude}`)
-                            .join('|') || undefined;
+                        Array.from(
+                            new Set(locations.slice(1, -1).map((loc) => `${loc.longitude},${loc.latitude}`))
+                        ).join('|') || undefined;
 
                     return fetchRoute(start, goal, waypoints);
                 })

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -16,12 +16,15 @@ const buttonVariants = cva(
                 ghost: 'hover:bg-accent hover:text-accent-foreground',
                 signature: 'bg-[#D44646] text-white shadow-sm hover:bg-destructive/90',
                 link: 'text-primary underline-offset-4 hover:underline',
+                gps: 'bg-white text-destructive drop-shadow-xl hover:bg-destructive hover:text-white',
+                reset: 'bg-destructive text-white drop-shadow-xl hover:bg-white hover:text-destructive',
             },
             size: {
                 default: 'h-9 px-4 py-2',
                 sm: 'h-8 rounded-md px-3 text-xs',
                 lg: 'h-10 rounded-md px-8',
                 icon: 'h-9 w-9',
+                gps: 'p-3 rounded-[50%]',
             },
         },
         defaultVariants: {


### PR DESCRIPTION
## #️⃣연관된 이슈

#33 

## 📝작업 내용

- added arrows showing route of protest that has at least more then 2 locations
- calles naver api before loading main index map(cached 1hour)
- individual api route created to avoid cors issue when using naver api
- each location latitude, longitude string is checked for duplicate data before joining to single string
- gps(current location), reset(default position) button is added

## 💬리뷰 요구사항

- might want to look in to arrow generating logic for possible errors