### PR TITLE
fix: fixed reset button issue

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,11 @@
+{
+  "singleQuote": true,
+  "semi": true,
+  "trailingComma": "all",
+  "printWidth": 100,
+  "tabWidth": 2,
+  "bracketSpacing": true,
+  "arrowParens": "avoid",
+  "jsxSingleQuote": true,
+  "endOfLine": "auto"
+}

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -6,17 +6,19 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
 const compat = new FlatCompat({
-    baseDirectory: __dirname,
+  baseDirectory: __dirname,
 });
 
 const eslintConfig = [
-    ...compat.extends('next/core-web-vitals', 'next/typescript'),
-    {
-        rules: {
-            '@typescript-eslint/no-unused-vars': 'off',
-            '@typescript-eslint/no-explicit-any': 'warn',
-        },
+  ...compat.extends('next/core-web-vitals', 'next/typescript'),
+  {
+    rules: {
+      'no-console': 'warn',
+      quotes: ['error', 'single', { avoidEscape: true, allowTemplateLiterals: true }],
+      '@typescript-eslint/no-unused-vars': 'off',
+      '@typescript-eslint/no-explicit-any': 'warn',
     },
+  },
 ];
 
 export default eslintConfig;

--- a/src/app/(with-hamburger-button)/page.tsx
+++ b/src/app/(with-hamburger-button)/page.tsx
@@ -3,53 +3,53 @@ import KakaoMap from '@/components/KakaoMaps/KakaoMap';
 import { Metadata } from 'next';
 
 const keywords = [
-    '집회',
-    '서울 집회',
-    '오늘 집회 일정',
-    '광화문 집회',
-    '여의도 집회',
-    '국회의사당 집회',
-    '헌법재판소 집회',
-    '촛불집회',
-    '시위',
-    '서울 시위',
-    '오늘 시위 일정',
-    '광화문 시위',
-    '여의도 시위',
-    '국회의사당 시위',
-    '헌법재판소 시위',
-    '촛불시위',
-    '오늘의 집회/시위',
+  '집회',
+  '서울 집회',
+  '오늘 집회 일정',
+  '광화문 집회',
+  '여의도 집회',
+  '국회의사당 집회',
+  '헌법재판소 집회',
+  '촛불집회',
+  '시위',
+  '서울 시위',
+  '오늘 시위 일정',
+  '광화문 시위',
+  '여의도 시위',
+  '국회의사당 시위',
+  '헌법재판소 시위',
+  '촛불시위',
+  '오늘의 집회/시위',
 ].join(', ');
 
 export const metadata: Metadata = {
-    title: '주변 시위 Now | 오늘의 시위 정보와 집회 정보',
+  title: '주변 시위 Now | 오늘의 시위 정보와 집회 정보',
+  description: '주변 시위 정보를 지도로 한 눈에 볼 수 있도록 제공하는 서비스 입니다',
+  openGraph: {
+    title: '주변 시위 Now | 오늘의 시위, 집회 정보',
     description: '주변 시위 정보를 지도로 한 눈에 볼 수 있도록 제공하는 서비스 입니다',
-    openGraph: {
-        title: '주변 시위 Now | 오늘의 시위, 집회 정보',
-        description: '주변 시위 정보를 지도로 한 눈에 볼 수 있도록 제공하는 서비스 입니다',
-        images: [`${process.env.NEXT_PUBLIC_SERVER_DEV_URL}/images/thumbnail.png`],
-    },
-    icons: {
-        icon: '/images/favicon.ico',
-    },
-    keywords,
+    images: [`${process.env.NEXT_PUBLIC_SERVER_DEV_URL}/images/thumbnail.png`],
+  },
+  icons: {
+    icon: '/images/favicon.ico',
+  },
+  keywords,
 };
 
 export default async function Home() {
-    const protests = await getProtestInfos();
-    const latitude = 37.539581447331;
-    const longitude = 127.00787604008;
-    return (
-        <>
-            <KakaoMap
-                latitude={latitude}
-                longitude={longitude}
-                w='100%'
-                h='calc(100dvh - 14vh)'
-                l={8}
-                protests={protests}
-            />
-        </>
-    );
+  const protests = await getProtestInfos();
+  const latitude = 37.57297651;
+  const longitude = 126.9743513;
+  return (
+    <>
+      <KakaoMap
+        latitude={latitude}
+        longitude={longitude}
+        w='100%'
+        h='calc(100dvh - 14vh)'
+        l={8}
+        protests={protests}
+      />
+    </>
+  );
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -10,44 +10,44 @@ import TanStackProvider from '@/app/providers/TanStackProvider';
 import { SocketProvider } from '@/app/providers/SocketProvider';
 
 export const metadata: Metadata = {
-    verification: {
-        google: 'C7IMZBZEv09U7b7X4-rcEn7Fe1hpK5yE0EfGgNgxRPE',
-    },
-    other: {
-        'naver-site-verification': 'eef43fcd0d4ac4541e99553df2570bfa06bdc56a',
-    },
+  verification: {
+    google: 'C7IMZBZEv09U7b7X4-rcEn7Fe1hpK5yE0EfGgNgxRPE',
+  },
+  other: {
+    'naver-site-verification': 'eef43fcd0d4ac4541e99553df2570bfa06bdc56a',
+  },
 };
 
 export default function RootLayout({
-    children,
-    modal,
+  children,
+  modal,
 }: Readonly<{
-    children: ReactNode;
-    modal: ReactNode;
+  children: ReactNode;
+  modal: ReactNode;
 }>) {
-    const KAKAO_API_KEY = process.env.NEXT_PUBLIC_KAKAO_API_KEY;
+  const KAKAO_API_KEY = process.env.NEXT_PUBLIC_KAKAO_API_KEY;
 
-    return (
-        <html lang='kr'>
-            <body>
-                {process.env.NEXT_PUBLIC_GOOGLE_ANALYTICS && (
-                    <GoogleAnalytics gaId={process.env.NEXT_PUBLIC_GOOGLE_ANALYTICS} />
-                )}
-                <Header />
-                <Script
-                    strategy='lazyOnload'
-                    src={`//dapi.kakao.com/v2/maps/sdk.js?appkey=${KAKAO_API_KEY}&libraries=services&autoload=false`}
-                />
-                <Script strategy='lazyOnload' src='https://unpkg.com/heatmap.js' />
-                <TanStackProvider>
-                    <SocketProvider>
-                        <main>{children}</main>
-                        {modal}
-                        <Toaster />
-                    </SocketProvider>
-                </TanStackProvider>
-                <Footer />
-            </body>
-        </html>
-    );
+  return (
+    <html lang='kr'>
+      <body>
+        {process.env.NEXT_PUBLIC_GOOGLE_ANALYTICS && (
+          <GoogleAnalytics gaId={process.env.NEXT_PUBLIC_GOOGLE_ANALYTICS} />
+        )}
+        <Header />
+        <Script
+          strategy='lazyOnload'
+          src={`//dapi.kakao.com/v2/maps/sdk.js?appkey=${KAKAO_API_KEY}&libraries=services&autoload=false`}
+        />
+        <Script strategy='lazyOnload' src='https://unpkg.com/heatmap.js' />
+        <TanStackProvider>
+          <SocketProvider>
+            <main>{children}</main>
+            {modal}
+            <Toaster theme='system' richColors duration={2000} />
+          </SocketProvider>
+        </TanStackProvider>
+        <Footer />
+      </body>
+    </html>
+  );
 }

--- a/src/components/KakaoMaps/KakaoMap.tsx
+++ b/src/components/KakaoMaps/KakaoMap.tsx
@@ -7,301 +7,337 @@ import { Map, MapMarker, MapTypeControl, ZoomControl } from 'react-kakao-maps-sd
 import useKakaoLoader from '@/hooks/useKakaoLoader';
 import { ProtestData } from '@/types';
 import { calculateRealDistanceOnePixel } from '@/lib/utils';
-import { useGeoLocation } from '@/hooks/useGeoLocation';
 import { CurrentLocationButton } from '@/components/Button/CurrentLocationButton';
 import { CurrentLocationRestButton } from '@/components/Button/CurrentLocationRestButton';
 import { NavigationRouteLines } from '@/components/NaverDirections/NavigationRouteLines';
 import { ProtestMapMarkerList } from '@/components/Protest/ProtestMapMarkerList';
+import { toast } from 'sonner';
 
 export type RouteData = [number, number][];
 
+type CurrentPosition = {
+  lat: number;
+  long: number;
+};
+
 export default function KakaoMap({
-    latitude,
-    longitude,
-    w,
-    h,
-    l,
-    protests,
+  latitude,
+  longitude,
+  w,
+  h,
+  l,
+  protests,
 }: {
-    latitude: number;
-    longitude: number;
-    w: string;
-    h: string;
-    l: number;
-    protests: ProtestData[];
+  latitude: number;
+  longitude: number;
+  w: string;
+  h: string;
+  l: number;
+  protests: ProtestData[];
 }) {
-    const [loading, error] = useKakaoLoader();
-    const [heatmapInstance, setHeatmapInstance] = useState<any>(null);
-    const [mapInstance, setMapInstance] = useState<any>(null);
-    const [routeData, setRouteData] = useState<any>(null);
-    const [currentLevel, setCurrentLevel] = useState<number>(0);
-    const [agreed, setAgreed] = useState(false);
-    const [buttonClicked, setButtonClicked] = useState(false);
-    const [typeOfButton, setTypeOfButton] = useState('');
-    const [currentPositionMarker, setCurrentPositionMarker] = useState(false);
-    const router = useRouter();
-    const animationFrameRef = useRef<number | null>(null);
-    const isUpdatingRef = useRef(false);
-    const [realXDistance, setRealXDistance] = useState<number | null>();
-    const { curLocation, isLoading } = useGeoLocation(agreed);
+  const [loading, error] = useKakaoLoader();
+  const [heatmapInstance, setHeatmapInstance] = useState<any>(null);
+  const [mapInstance, setMapInstance] = useState<any>(null);
+  const [routeData, setRouteData] = useState<any>(null);
+  const [currentLevel, setCurrentLevel] = useState<number>(0);
+  const [currentPositionMarker, setCurrentPositionMarker] = useState<CurrentPosition | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const router = useRouter();
+  const animationFrameRef = useRef<number | null>(null);
+  const isUpdatingRef = useRef(false);
+  const [realXDistance, setRealXDistance] = useState<number | null>();
 
-    useEffect(() => {
-        if (!mapInstance || !protests) return;
-        const updateBounds = () => {
-            const SEOUL_CENTER_LONGITUDE = 127.0016985;
+  useEffect(() => {
+    if (!mapInstance || !protests) return;
+    const updateBounds = () => {
+      const SEOUL_CENTER_LONGITUDE = 127.0016985;
 
-            const { ha, qa, oa, pa } = mapInstance.getBounds();
-            const d =
-                calculateRealDistanceOnePixel(ha, SEOUL_CENTER_LONGITUDE, oa, SEOUL_CENTER_LONGITUDE) /
-                window.innerWidth;
-            setRealXDistance((prev) => {
-                if (prev === d) return prev;
-                return d;
-            });
-        };
-        updateBounds();
-        window.kakao.maps.event.addListener(mapInstance, 'bounds_changed', updateBounds);
-        return () => {
-            window.kakao.maps.event.removeListener(mapInstance, 'bounds_changed', updateBounds);
-        };
-    }, [mapInstance, protests]);
-
-    const onButtonClick = (type: string) => {
-        setButtonClicked(true);
-        if (mapInstance) {
-            if (type === 'gps') {
-                setAgreed(true);
-                setTypeOfButton('gps');
-            } else {
-                setTypeOfButton('reset');
-            }
-        }
+      const { ha, qa, oa, pa } = mapInstance.getBounds();
+      const d =
+        calculateRealDistanceOnePixel(ha, SEOUL_CENTER_LONGITUDE, oa, SEOUL_CENTER_LONGITUDE) /
+        window.innerWidth;
+      setRealXDistance(prev => {
+        if (prev === d) return prev;
+        return d;
+      });
     };
-
-    useEffect(() => {
-        if (!isLoading && curLocation && mapInstance) {
-            if (typeOfButton === 'gps') {
-                const destLatLng = new kakao.maps.LatLng(curLocation.latitude, curLocation.longitude);
-                setCurrentPositionMarker(true);
-                mapInstance.setLevel(2);
-                mapInstance.panTo(destLatLng);
-                setAgreed(false);
-                setButtonClicked(false);
-            } else {
-                const destLatLng = new kakao.maps.LatLng(37.539581447331, 127.00787604008);
-                setCurrentPositionMarker(false);
-                mapInstance.setLevel(7);
-                mapInstance.panTo(destLatLng);
-                setButtonClicked(false);
-            }
-        }
-    }, [agreed, isLoading, curLocation, mapInstance, buttonClicked]);
-
-    const updateHeatmap = useCallback(() => {
-        if (!heatmapInstance || !mapInstance || !realXDistance) return;
-
-        setCurrentLevel(mapInstance.getLevel());
-
-        isUpdatingRef.current = true;
-
-        if (animationFrameRef.current) {
-            cancelAnimationFrame(animationFrameRef.current);
-        }
-
-        animationFrameRef.current = requestAnimationFrame(() => {
-            const projection = mapInstance.getProjection();
-            const bounds = mapInstance.getBounds();
-
-            const heatmapData = protests
-                .map((protest) => {
-                    const latLng = new window.kakao.maps.LatLng(
-                        protest.locations[0].latitude,
-                        protest.locations[0].longitude
-                    );
-
-                    const pixel = projection.pointFromCoords(latLng);
-                    return {
-                        x: pixel.x - projection.pointFromCoords(bounds.getSouthWest()).x,
-                        y: pixel.y - projection.pointFromCoords(bounds.getNorthEast()).y,
-                        value: protest.declaredParticipants,
-                        radius: protest.radius / realXDistance,
-                    };
-                })
-                .filter(Boolean);
-
-            heatmapInstance.setData({
-                max: 10000,
-                min: 100,
-                data: heatmapData,
-            });
-            const canvas = heatmapInstance._renderer.canvas;
-            if (canvas) {
-                canvas.style.display = 'block';
-                canvas.style.opacity = '1';
-                canvas.style.zIndex = '10';
-                canvas.style.pointerEvents = 'none';
-            }
-        });
-
-        isUpdatingRef.current = false;
-    }, [heatmapInstance, mapInstance, protests, realXDistance]);
-
-    const registerMapEvents = useCallback(() => {
-        if (!mapInstance) return;
-
-        window.kakao.maps.event.addListener(mapInstance, 'zoom_start', () => {
-            updateHeatmap();
-        });
-
-        window.kakao.maps.event.addListener(mapInstance, 'center_changed', () => {
-            updateHeatmap();
-        });
-
-        window.kakao.maps.event.addListener(mapInstance, 'zoom_changed', () => {
-            updateHeatmap();
-        });
-    }, [mapInstance, updateHeatmap, realXDistance]);
-
-    useEffect(() => {
-        if (!mapInstance) return;
-        setCurrentLevel(mapInstance.getLevel());
-    }, [mapInstance]);
-
-    useEffect(() => {
-        if (!mapInstance || heatmapInstance) return;
-
-        const script = document.createElement('script');
-        script.src = 'https://unpkg.com/heatmap.js';
-        script.async = true;
-        script.onload = () => {
-            const container = document.getElementById('map');
-            if (!container) return;
-
-            const heatmap = (window as any).h337.create({
-                container,
-                maxOpacity: 0.4,
-                minOpacity: 0.1,
-                blur: 0.95,
-            });
-
-            setHeatmapInstance(heatmap);
-
-            const canvas = heatmap._renderer.canvas;
-            if (canvas) {
-                canvas.style.zIndex = '10';
-                canvas.style.pointerEvents = 'none';
-            }
-        };
-        document.head.appendChild(script);
-
-        return () => {
-            document.head.removeChild(script);
-        };
-    }, [mapInstance, heatmapInstance]);
-
-    useEffect(() => {
-        if (!mapInstance) return;
-
-        registerMapEvents();
-
-        return () => {
-            if (mapInstance) {
-                window.kakao.maps.event.removeListener(mapInstance, 'zoom_start', updateHeatmap);
-                window.kakao.maps.event.removeListener(mapInstance, 'center_changed', updateHeatmap);
-                window.kakao.maps.event.removeListener(mapInstance, 'zoom_changed', updateHeatmap);
-                if (animationFrameRef.current) {
-                    cancelAnimationFrame(animationFrameRef.current);
-                }
-            }
-        };
-    }, [mapInstance, registerMapEvents]);
-
-    useEffect(() => {
-        if (heatmapInstance && mapInstance) {
-            updateHeatmap();
-        }
-    }, [heatmapInstance, mapInstance, updateHeatmap]);
-
-    const fetchRoute = async (start: string, goal: string, waypoints?: string) => {
-        const url = new URL(`/next-api/directions/route`, window.location.origin);
-        url.searchParams.append('start', start);
-        url.searchParams.append('goal', goal);
-
-        if (waypoints) {
-            url.searchParams.append('waypoints', waypoints);
-        }
-        try {
-            const res = await fetch(url.toString());
-            const data = await res.json();
-            if (data.code === 0) {
-                return data.route ? data.route.trafast[0].path : [];
-            }
-            if (data.code === 1) {
-                return [];
-            }
-        } catch (e) {
-            return [];
-        }
+    updateBounds();
+    window.kakao.maps.event.addListener(mapInstance, 'bounds_changed', updateBounds);
+    return () => {
+      window.kakao.maps.event.removeListener(mapInstance, 'bounds_changed', updateBounds);
     };
+  }, [mapInstance, protests]);
 
-    const fetchMultipleRoutes = async (protests: ProtestData[]) => {
-        const results = await Promise.all(
-            protests
-                .filter(({ locations }) => locations.length >= 2)
-                .map(({ locations }) => {
-                    const start = `${locations[0].longitude},${locations[0].latitude}`;
-                    const goal = `${locations[locations.length - 1].longitude},${
-                        locations[locations.length - 1].latitude
-                    }`;
-                    const waypoints =
-                        Array.from(
-                            new Set(locations.slice(1, -1).map((loc) => `${loc.longitude},${loc.latitude}`))
-                        ).join('|') || undefined;
-                    return fetchRoute(start, goal, waypoints);
-                })
+  const onGpsButtonClick = () => {
+    setIsLoading(true);
+    navigator.geolocation.getCurrentPosition(
+      position => {
+        const destLatLng = new kakao.maps.LatLng(
+          position.coords.latitude,
+          position.coords.longitude,
         );
-        return results;
-    };
-
-    const handleFetchRoutes = async () => {
-        const routes = await fetchMultipleRoutes(protests);
-        setRouteData(routes);
-    };
-
-    useEffect(() => {
-        handleFetchRoutes();
-    }, [protests]);
-
-    if (loading) return <div>Loading ... loading</div>;
-    if (error) return <div>Loading ... error</div>;
-    if (!routeData) return <div>Loading...</div>;
-
-    return (
-        <div className='relative'>
-            <Map
-                id='map'
-                center={{
-                    lat: latitude,
-                    lng: longitude,
-                }}
-                style={{
-                    margin: '0 auto',
-                    width: w,
-                    height: h,
-                }}
-                level={l}
-                onCreate={setMapInstance}
-            >
-                {currentLevel <= 8 && <NavigationRouteLines routeData={routeData} />}
-                {currentPositionMarker ?? (
-                    <MapMarker position={{ lat: curLocation!.latitude, lng: curLocation!.longitude }} />
-                )}
-                <ProtestMapMarkerList protests={protests} mapInstance={mapInstance} router={router} />
-                <MapTypeControl position={'TOPLEFT'} />
-                <ZoomControl position={'LEFT'} />
-            </Map>
-            <CurrentLocationButton onClick={() => onButtonClick('gps')} isLoading={isLoading} />
-            <CurrentLocationRestButton onClick={() => onButtonClick('reset')} />
-        </div>
+        setCurrentPositionMarker({
+          lat: position.coords.latitude,
+          long: position.coords.longitude,
+        });
+        setIsLoading(false);
+        mapInstance.setLevel(3);
+        mapInstance.panTo(destLatLng);
+        toast.success('위치 정보 가져오기 성공');
+      },
+      error => {
+        switch (error.code) {
+          case error.PERMISSION_DENIED:
+            toast.error('현재 위치를 가져올 수 없습니다.', {
+              description: '위치 접근 권한이 필요합니다. 브라우저 설정을 확인해주세요.',
+            });
+            setIsLoading(false);
+            break;
+          case error.POSITION_UNAVAILABLE:
+            toast.error('현재 위치를 가져올 수 없습니다.', {
+              description: '현재 위치를 확인할 수 없습니다. GPS 상태를 확인해주세요.',
+            });
+            setIsLoading(false);
+            break;
+          case error.TIMEOUT:
+            toast.error('현재 위치를 가져올 수 없습니다.', {
+              description: '위치 요청 시간이 초과되었습니다. 다시 시도해주세요.',
+            });
+            setIsLoading(false);
+            break;
+          default:
+            toast.error('알 수 없는 오류가 발생했습니다. 다시 시도해주세요.');
+            setIsLoading(false);
+            break;
+        }
+        console.error('위치 가져오기 실패', error);
+        setIsLoading(false);
+      },
+      {
+        enableHighAccuracy: true,
+        timeout: 10000,
+        maximumAge: 0,
+      },
     );
+  };
+
+  const onResetButtonClick = () => {
+    if (mapInstance) {
+      const destLatLng = new kakao.maps.LatLng(37.57297651, 126.9743513);
+      setCurrentPositionMarker({ lat: 0, long: 0 });
+      mapInstance.setLevel(5);
+      mapInstance.panTo(destLatLng);
+      toast.success('초기 위치로 이동!');
+    }
+  };
+
+  const updateHeatmap = useCallback(() => {
+    if (!heatmapInstance || !mapInstance || !realXDistance) return;
+
+    setCurrentLevel(mapInstance.getLevel());
+
+    isUpdatingRef.current = true;
+
+    if (animationFrameRef.current) {
+      cancelAnimationFrame(animationFrameRef.current);
+    }
+
+    animationFrameRef.current = requestAnimationFrame(() => {
+      const projection = mapInstance.getProjection();
+      const bounds = mapInstance.getBounds();
+
+      const heatmapData = protests
+        .map(protest => {
+          const latLng = new window.kakao.maps.LatLng(
+            protest.locations[0].latitude,
+            protest.locations[0].longitude,
+          );
+
+          const pixel = projection.pointFromCoords(latLng);
+          return {
+            x: pixel.x - projection.pointFromCoords(bounds.getSouthWest()).x,
+            y: pixel.y - projection.pointFromCoords(bounds.getNorthEast()).y,
+            value: protest.declaredParticipants,
+            radius: protest.radius / realXDistance,
+          };
+        })
+        .filter(Boolean);
+
+      heatmapInstance.setData({
+        max: 10000,
+        min: 100,
+        data: heatmapData,
+      });
+      const canvas = heatmapInstance._renderer.canvas;
+      if (canvas) {
+        canvas.style.display = 'block';
+        canvas.style.opacity = '1';
+        canvas.style.zIndex = '10';
+        canvas.style.pointerEvents = 'none';
+      }
+    });
+
+    isUpdatingRef.current = false;
+  }, [heatmapInstance, mapInstance, protests, realXDistance]);
+
+  const registerMapEvents = useCallback(() => {
+    if (!mapInstance) return;
+
+    window.kakao.maps.event.addListener(mapInstance, 'zoom_start', () => {
+      updateHeatmap();
+    });
+
+    window.kakao.maps.event.addListener(mapInstance, 'center_changed', () => {
+      updateHeatmap();
+    });
+
+    window.kakao.maps.event.addListener(mapInstance, 'zoom_changed', () => {
+      updateHeatmap();
+    });
+  }, [mapInstance, updateHeatmap, realXDistance]);
+
+  useEffect(() => {
+    if (!mapInstance) return;
+    setCurrentLevel(mapInstance.getLevel());
+  }, [mapInstance]);
+
+  useEffect(() => {
+    if (!mapInstance || heatmapInstance) return;
+
+    const script = document.createElement('script');
+    script.src = 'https://unpkg.com/heatmap.js';
+    script.async = true;
+    script.onload = () => {
+      const container = document.getElementById('map');
+      if (!container) return;
+
+      const heatmap = (window as any).h337.create({
+        container,
+        maxOpacity: 0.4,
+        minOpacity: 0.1,
+        blur: 0.95,
+      });
+
+      setHeatmapInstance(heatmap);
+
+      const canvas = heatmap._renderer.canvas;
+      if (canvas) {
+        canvas.style.zIndex = '10';
+        canvas.style.pointerEvents = 'none';
+      }
+    };
+    document.head.appendChild(script);
+
+    return () => {
+      document.head.removeChild(script);
+    };
+  }, [mapInstance, heatmapInstance]);
+
+  useEffect(() => {
+    if (!mapInstance) return;
+
+    registerMapEvents();
+
+    return () => {
+      if (mapInstance) {
+        window.kakao.maps.event.removeListener(mapInstance, 'zoom_start', updateHeatmap);
+        window.kakao.maps.event.removeListener(mapInstance, 'center_changed', updateHeatmap);
+        window.kakao.maps.event.removeListener(mapInstance, 'zoom_changed', updateHeatmap);
+        if (animationFrameRef.current) {
+          cancelAnimationFrame(animationFrameRef.current);
+        }
+      }
+    };
+  }, [mapInstance, registerMapEvents]);
+
+  useEffect(() => {
+    if (heatmapInstance && mapInstance) {
+      updateHeatmap();
+    }
+  }, [heatmapInstance, mapInstance, updateHeatmap]);
+
+  const fetchRoute = async (start: string, goal: string, waypoints?: string) => {
+    const url = new URL(`/next-api/directions/route`, window.location.origin);
+    url.searchParams.append('start', start);
+    url.searchParams.append('goal', goal);
+
+    if (waypoints) {
+      url.searchParams.append('waypoints', waypoints);
+    }
+    try {
+      const res = await fetch(url.toString());
+      const data = await res.json();
+      if (data.code === 0) {
+        return data.route ? data.route.trafast[0].path : [];
+      }
+      if (data.code === 1) {
+        return [];
+      }
+    } catch (e) {
+      return [];
+    }
+  };
+
+  const fetchMultipleRoutes = async (protests: ProtestData[]) => {
+    const results = await Promise.all(
+      protests
+        .filter(({ locations }) => locations.length >= 2)
+        .map(({ locations }) => {
+          const start = `${locations[0].longitude},${locations[0].latitude}`;
+          const goal = `${locations[locations.length - 1].longitude},${
+            locations[locations.length - 1].latitude
+          }`;
+          const waypoints =
+            Array.from(
+              new Set(locations.slice(1, -1).map(loc => `${loc.longitude},${loc.latitude}`)),
+            ).join('|') || undefined;
+          return fetchRoute(start, goal, waypoints);
+        }),
+    );
+    return results;
+  };
+
+  const handleFetchRoutes = async () => {
+    const routes = await fetchMultipleRoutes(protests);
+    setRouteData(routes);
+  };
+
+  useEffect(() => {
+    handleFetchRoutes();
+  }, [protests]);
+
+  if (loading) return <div>Loading ... loading</div>;
+  if (error) return <div>Loading ... error</div>;
+  if (!routeData) return <div>Loading...</div>;
+
+  return (
+    <div className='relative'>
+      <Map
+        id='map'
+        center={{
+          lat: latitude,
+          lng: longitude,
+        }}
+        style={{
+          margin: '0 auto',
+          width: w,
+          height: h,
+        }}
+        level={l}
+        onCreate={setMapInstance}
+      >
+        {currentLevel <= 8 && <NavigationRouteLines routeData={routeData} />}
+        {currentPositionMarker && (
+          <MapMarker
+            position={{ lat: currentPositionMarker.lat, lng: currentPositionMarker.long }}
+          />
+        )}
+        <ProtestMapMarkerList protests={protests} mapInstance={mapInstance} router={router} />
+        <MapTypeControl position={'TOPLEFT'} />
+        <ZoomControl position={'LEFT'} />
+      </Map>
+      <CurrentLocationButton onClick={() => onGpsButtonClick()} isLoading={isLoading} />
+      <CurrentLocationRestButton onClick={() => onResetButtonClick()} />
+    </div>
+  );
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

- #56 

## 📝작업 내용

- 기존 reset, gps 버튼 핸들러가 하나로 되어있어 높은 의존성으로 인해 에러가 발생하고 있었기 때문에 핸들러를 분리
- 기존에 위치 인증을 위해 사용하던 geolocation 훅을 가져와서 사용하고 있었는데, 해당 훅의 작동 시점, loading 처리를 위한 여러 상태가 불필요하게 사용되고 있는 상황을 인지하고, 브라우저에서 제공하는 navigator.geolocation으로 변경
  - 해당 error 와 loading 처리는 toaster과 spinner로 사용자에게 보여줄 수 있도록 함
- 불필요한 state들(버튼클릭여부, 버튼의 type이 reset 인지 gps인지 등)을 제거하고, 기존에 사용하던 currentPositionMarker 의 state로 현재 위치의 위, 경도를 관리하도록 함
- 기존 지도의 초기 위치를 운석열 관저에서 종로 경찰서로 바꾸며, 확대 수준을 5로 확대
- prettier 설정과 eslint 설정 추가(간단한 거라 끼워 넣었음)
  -  따옴표를 사용할 때 홑 따옴표를 사용할 수 있도록 하고, 부가적으로 
    - 문장 끝에 세미콜론(;)을 붙임
    - 여러 줄로 나열되는 객체나 배열 등에서 마지막 요소 뒤에 콤마를 붙임
    - 한 줄에 최대 몇 글자까지 출력할지 설정. 100 초과되면 줄바꿈
    - 들여쓰기 시 사용하는 공백 수 2로 통일
    - 객체 리터럴에서 중괄호 {} 안쪽에 띄어쓰기
    - 화살표 함수 매개변수가 하나일 때 괄호 생략
    - JSX 속성에 작은따옴표 사용(tsx도 마찬가지)
    - 자동 줄바꿈 문자 설정
    - 콘솔이 있을 경우 warning(console.log 지우기 용이하도록)

### 스크린샷 (선택)

![스크린샷 2025-04-08 오전 11 49 26](https://github.com/user-attach

![스크린샷 2025-04-08 오전 11 49 55](https://github.com/user-attachments/assets/ea824840-e622-4d57-87cb-778ff0bb2954)
ments/assets/48359ffc-11be-4c62-bd5f-dfe64f628581)

## 💬리뷰 요구사항(선택)

- geolocation 예외 처리에서 누락 된 것은 없을지 부탁드립니다.
- 버튼 작동에 이상은 없는 지 확인 부탁드립니다.
