### PR TITLE
[FE] feat : 응원하기 로딩 및 실패 시 UI 를 추가한다

### DIFF
--- a/src/apis/cheer/index.ts
+++ b/src/apis/cheer/index.ts
@@ -7,7 +7,7 @@ export const ProtestsCheerCount = async () => {
 };
 
 export const ProtestCheerCount = async (protestId: string) => {
-  const response = await fetch(`${SERVER_URL}/api/cheer/protesㅇt/${protestId}`);
+  const response = await fetch(`${SERVER_URL}/api/cheer/protest/${protestId}`);
   const data = await response.json();
   return data;
 };

--- a/src/apis/cheer/index.ts
+++ b/src/apis/cheer/index.ts
@@ -7,7 +7,7 @@ export const ProtestsCheerCount = async () => {
 };
 
 export const ProtestCheerCount = async (protestId: string) => {
-  const response = await fetch(`${SERVER_URL}/api/cheer/protest/${protestId}`);
+  const response = await fetch(`${SERVER_URL}/api/cheer/protesㅇt/${protestId}`);
   const data = await response.json();
   return data;
 };

--- a/src/components/Protest/ProtestDetailCheer.tsx
+++ b/src/components/Protest/ProtestDetailCheer.tsx
@@ -19,7 +19,6 @@ export const ProtestDetailCheer = ({ protestId }: { protestId: string }) => {
       confettiNumber: 30,
     });
   };
-  console.log(data, isError, isLoading);
   return (
     <div className='flex flex-col justify-center items-center  '>
       <ProtestActionButton

--- a/src/components/Protest/ProtestDetailCheer.tsx
+++ b/src/components/Protest/ProtestDetailCheer.tsx
@@ -8,11 +8,10 @@ import Image from 'next/image';
 import { numberTransfer } from '@/lib/utils';
 
 export const ProtestDetailCheer = ({ protestId }: { protestId: string }) => {
-  const { data } = UseProtestCheerCount(protestId);
+  const { data, isLoading, isError } = UseProtestCheerCount(protestId);
   const { effect } = useCheerEffect(data);
   const { mutate } = SendCheerMutation(String(protestId));
   const { getConfetti } = useConfetti();
-
   const handleConffeti = () => {
     getConfetti().addConfetti({
       emojis: ['🔥', '✔️', '❤️'],
@@ -20,6 +19,7 @@ export const ProtestDetailCheer = ({ protestId }: { protestId: string }) => {
       confettiNumber: 30,
     });
   };
+  console.log(data, isError, isLoading);
   return (
     <div className='flex flex-col justify-center items-center  '>
       <ProtestActionButton
@@ -27,13 +27,22 @@ export const ProtestDetailCheer = ({ protestId }: { protestId: string }) => {
           handleConffeti();
           mutate(String(protestId));
         }}
+        disabled={isLoading || isError || !data}
       >
-        {effect ? (
-          <div className='animate-bounce'>🔥</div>
+        {isLoading ? (
+          <div className='animate-spin'>⟳</div>
+        ) : isError || !data ? (
+          <div>⚠️</div>
         ) : (
-          <Image src='/images/torch.png' alt='torch image' width={10} height={10} />
+          <>
+            {effect ? (
+              <div className='animate-bounce'>🔥</div>
+            ) : (
+              <Image src='/images/torch.png' alt='torch image' width={10} height={10} />
+            )}
+            <span className='text-sm text-white'>{numberTransfer(data.cheerCount)} 응원하기</span>
+          </>
         )}
-        <span className='text-sm text-white'> {numberTransfer(data?.cheerCount || 0)} 응원</span>
       </ProtestActionButton>
     </div>
   );

--- a/src/components/Protest/ProtestMapMarker.tsx
+++ b/src/components/Protest/ProtestMapMarker.tsx
@@ -62,7 +62,7 @@ export default function ProtestMapMarker({
         >
           {effect && <div className='absolute bottom-10'>🔥</div>}
           <span className='text-xs pb-2 font-sans font-bold'>
-            {isLoading ? '🔥 ...' : isError ? '🔥 --' : numberTransfer(data?.cheerCount || 0)}
+            {isLoading ? '🔥 ...' : isError || !data ? '0' : numberTransfer(data.cheerCount)}
           </span>
         </div>
       </CustomOverlayMap>

--- a/src/components/Protest/ProtestMapMarker.tsx
+++ b/src/components/Protest/ProtestMapMarker.tsx
@@ -42,9 +42,8 @@ export default function ProtestMapMarker({
     }
     router.push(`/protest/${id}`);
   };
-  const { data } = UseProtestCheerCount(protest.id);
+  const { data, isLoading, isError } = UseProtestCheerCount(protest.id);
   const { effect } = useCheerEffect(data);
-
   return (
     <div>
       <CustomOverlayMap
@@ -63,7 +62,7 @@ export default function ProtestMapMarker({
         >
           {effect && <div className='absolute bottom-10'>🔥</div>}
           <span className='text-xs pb-2 font-sans font-bold'>
-            {numberTransfer(data?.cheerCount || 0)}
+            {isLoading ? '🔥 ...' : isError ? '🔥 --' : numberTransfer(data?.cheerCount || 0)}
           </span>
         </div>
       </CustomOverlayMap>

--- a/src/hooks/UseProtestCheerCount.ts
+++ b/src/hooks/UseProtestCheerCount.ts
@@ -9,7 +9,7 @@ export const UseProtestCheerCount = (protestId: string) => {
   const { data, isLoading, isError } = useQuery({
     queryKey: ['cheer', protestId],
     queryFn: () => ProtestCheerCount(protestId),
-    refetchInterval: 3000,
+    refetchInterval: query => (query.state.error ? false : 3000),
     enabled: !isDetail || (isDetail && currentProtestId === protestId),
   });
   return { data: data?.data, isLoading, isError };


### PR DESCRIPTION
## #️⃣연관된 이슈

> #72 

## 📝작업 내용

> react qeury를 사용하여 응원하기 api 요청중 상태와 실패시 상태를 처리하였습니다.
- 메인 마커에서 
    - 실패시 : 응원수 0 보여줌 : 에러로 표기하면 사용자가 아무것도 안하고 탈주할 것 같아서 이렇게 진행했습니다.
    - 로딩중 : '🔥 ...'
- 상세페이지 
    - 실패시 : 버튼 비활성화 및 ⚠️ 아이콘 제공
    - 로딩시 : 버튼 비활성화 및  ⟳ 아이콘 회전며 제공

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 현재 리엑트 쿼리로 폴링을 진행중인데 api 요청 실패시 폴링 요청을 그만두는 방법을 잘 모르겠습니다.
