### PR TITLE
[FE] Bug : 드래그 시 시위 경로가 올바른 위치에서 벗어나는 문제를 해결한다

### DIFF
--- a/src/components/KakaoMaps/KakaoMap.tsx
+++ b/src/components/KakaoMaps/KakaoMap.tsx
@@ -43,6 +43,7 @@ export default function KakaoMap({
   const [currentLevel, setCurrentLevel] = useState<number>(0);
   const [currentPositionMarker, setCurrentPositionMarker] = useState<CurrentPosition | null>(null);
   const [isLoading, setIsLoading] = useState(false);
+  const [isDragging, setIsDragging] = useState(false);
   const router = useRouter();
   const animationFrameRef = useRef<number | null>(null);
   const isUpdatingRef = useRef(false);
@@ -307,6 +308,14 @@ export default function KakaoMap({
     handleFetchRoutes();
   }, [protests]);
 
+  const handleDragStart = () => {
+    setIsDragging(true);
+  };
+
+  const handleDragEnd = () => {
+    setIsDragging(false);
+  };
+
   if (loading || !routeData) return <MapLoadingFallback />;
   if (error) return <MapErrorFallback />;
 
@@ -325,8 +334,10 @@ export default function KakaoMap({
         }}
         level={l}
         onCreate={setMapInstance}
+        onDragStart={handleDragStart}
+        onDragEnd={handleDragEnd}
       >
-        {currentLevel <= 8 && <NavigationRouteLines routeData={routeData} />}
+        {currentLevel <= 8 && !isDragging && <NavigationRouteLines routeData={routeData} />}
         {currentPositionMarker && (
           <MapMarker
             position={{ lat: currentPositionMarker.lat, lng: currentPositionMarker.long }}


### PR DESCRIPTION
## #️⃣연관된 이슈

#62 

## 📝작업 내용

- 드래그 중 isDragging 상태를 추가한다
- react-kakao-maps에서 제공하는 이벤트인 onDragStart와 onDragEnd를 사용하여 드래그 중일때는 true, 끝나는 순간 false 가 될 수 있도록 한다
- 시위 경로를 그리는 Polyline 컴포넌트는 드래그 중이 아닐때만 보여줄 수 있도록 한다

### 스크린샷 (선택)

-

## 💬리뷰 요구사항(선택)

-
