### PR TITLE
[FE] bug : 캐시 무효화가 작동하지 않는 버그를 해결한다

### DIFF
--- a/next-sitemap.config.js
+++ b/next-sitemap.config.js
@@ -9,7 +9,7 @@ const config = {
 
     try {
       const response = await fetch(`${SERVER_URL}/api/protest?date=${date}`, {
-        next: { revalidate: 3600 },
+        next: { revalidate: 3600, tags: ['sitemap'] },
       });
 
       if (!response.ok) {

--- a/src/apis/protest/index.ts
+++ b/src/apis/protest/index.ts
@@ -3,7 +3,7 @@ import { notFound } from 'next/navigation';
 
 export const getProtestList = async () => {
   const response = await fetch(`${SERVER_URL}/api/protest?date=${targetDate}`, {
-    next: { revalidate: 3600 },
+    next: { revalidate: 3600, tags: ['protestList'] },
   });
   if (!response.ok) {
     throw new Error(response.statusText);
@@ -24,18 +24,4 @@ export const getProtestDetail = async (id: string) => {
 
   const protest = await response.json();
   return protest.data;
-};
-
-export const getProtestInfos = async () => {
-  const response = await fetch(`${SERVER_URL}/api/protest?date=${targetDate}`, {
-    next: { revalidate: 3600 },
-  });
-  if (!response.ok) {
-    if (response.status === 404) {
-      notFound();
-    }
-    throw new Error(response.statusText);
-  }
-  const protests = await response.json();
-  return protests.data;
 };

--- a/src/app/(with-hamburger-button)/page.tsx
+++ b/src/app/(with-hamburger-button)/page.tsx
@@ -1,4 +1,4 @@
-import { getProtestInfos } from '@/apis/protest';
+import { getProtestList } from '@/apis/protest';
 import KakaoMap from '@/components/KakaoMaps/KakaoMap';
 import { Metadata } from 'next';
 
@@ -37,7 +37,7 @@ export const metadata: Metadata = {
 };
 
 export default async function Home() {
-  const protests = await getProtestInfos();
+  const protests = await getProtestList();
   const latitude = 37.57297651;
   const longitude = 126.9743513;
   return (

--- a/src/app/v1/revalidate/protests/route.ts
+++ b/src/app/v1/revalidate/protests/route.ts
@@ -1,7 +1,8 @@
 import { NextResponse } from 'next/server';
-import { revalidatePath } from 'next/cache';
+import { revalidatePath, revalidateTag } from 'next/cache';
 
 export async function GET() {
-  revalidatePath('/', 'layout');
+  revalidateTag('protestList');
+  revalidateTag('sitmap');
   return NextResponse.json({ success: true, message: 'Cache invalidated' });
 }

--- a/src/components/Protest/protest-list.tsx
+++ b/src/components/Protest/protest-list.tsx
@@ -9,10 +9,10 @@ import {
 import { GiHamburgerMenu } from 'react-icons/gi';
 import ProtestCard from './protest-card';
 import { ProtestData } from '@/types';
-import { getProtestInfos } from '@/apis/protest';
+import { getProtestList } from '@/apis/protest';
 
 export default async function ProtestList() {
-  const protests = await getProtestInfos();
+  const protests = await getProtestList();
   return (
     <Sheet>
       <SheetTrigger className='absolute top-12 right-0 p-2 rounded-s-md bg-[#D44646] text-2xl text-background-white z-10'>


### PR DESCRIPTION
## #️⃣연관된 이슈

#85 

## 📝작업 내용

- 기존에 중복되고 있던 api 요청 함수 getProtestInfos와 getProtestList 중 getProtestList로 통일한다
- 기존에 revalidatePath()로 '/' 하위 layout의 서버 컴포넌트는 모두 캐시를 무효화 하는 방식이였지만 이는 불필요한 캐시까지 무효화 하기 때문에 각각 tag를 부여하여 revalidateTag()로 특정 타깃을 겨냥하여 캐시를 무효화 할 수 있도록 수정하였다
- 기존에 시간 기준과 tag 기준 revalidation은 함께 사용할 수 없다는 말이 있었는데 테스트 결과  이는 루머였던 것으로 결론지었다

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.
