### PR TITLE
[FE] Bug : heatmap의 리렌더가 과도하게 발생하여 canvas가 완전하지 않을 때 접근하여 발생하는 에러를 해결하고 리렌더를 최적화 한다

### DIFF
--- a/src/hooks/useThrottledHeatmapUpdate.ts
+++ b/src/hooks/useThrottledHeatmapUpdate.ts
@@ -1,0 +1,100 @@
+import { shouldRenderHeatmap, throttle } from '@/lib/utils';
+import { ProtestData } from '@/types';
+import { useCallback, useEffect, useMemo, useRef } from 'react';
+
+type Params = {
+  mapInstance: kakao.maps.Map | null;
+  heatmapInstance: any;
+  protests: ProtestData[];
+  realXDistance: number | null | undefined;
+};
+
+export const useThrottledHeatmapUpdate = ({
+  mapInstance,
+  heatmapInstance,
+  protests,
+  realXDistance,
+}: Params) => {
+  const animationFrameRef = useRef<number | null>(null); //rAF 예약 Id 저장용
+
+  const updateHeatmap = useCallback(() => {
+    // 실제 heatmap 데이터를 계산하고 setData()로 업데이트 하는 함수
+    if (!mapInstance || !heatmapInstance || !realXDistance) return;
+
+    const projection = mapInstance.getProjection(); // 지도의 위 경도를 화변의 픽셀 좌표로 변경
+    const bounds = mapInstance.getBounds(); // 현재 눈에 보이는 뷰포트 기준 사각형
+
+    const heatmapData = protests
+      .map(protest => {
+        const latLng = new window.kakao.maps.LatLng(
+          protest.locations[0].latitude,
+          protest.locations[0].longitude,
+        ); // 시위 위치의 위 경도를 LatLng 객체로 변환
+
+        const pixel = projection.pointFromCoords(latLng);
+
+        return {
+          // 왼쪽 위 (0,0) 기준 위경도를 픽셀좌표로 바꾸어
+          x: pixel.x - projection.pointFromCoords(bounds.getSouthWest()).x, // 연산 지도 좌하단에서 얼마나 떨어졌는지
+          y: pixel.y - projection.pointFromCoords(bounds.getNorthEast()).y, // 지도 우상단에서 얼마나 떨어졌는지
+          value: protest.declaredParticipants,
+          radius: protest.radius / realXDistance,
+        }; // 히트맵 용 {x, y, value, radius}
+      })
+      .filter(Boolean); // 혹여 null, undefined 제거
+
+    if (!shouldRenderHeatmap({ mapInstance, heatmapInstance })) {
+      console.warn('heatmap hide!');
+      return;
+    }
+
+    heatmapInstance.setData({
+      max: 10000,
+      min: 100,
+      data: heatmapData,
+    });
+  }, [mapInstance, heatmapInstance, protests, realXDistance]);
+
+  const throttledUpdate = useMemo(() => {
+    // 고차함수인 throttle()의 리턴 된 fn을 캐싱
+    return throttle(() => {
+      if (animationFrameRef.current) return;
+      animationFrameRef.current = requestAnimationFrame(() => {
+        updateHeatmap();
+        animationFrameRef.current = null;
+      });
+    }, 100);
+  }, [updateHeatmap]);
+
+  useEffect(() => {
+    if (heatmapInstance && mapInstance) {
+      updateHeatmap();
+    }
+  }, [heatmapInstance, mapInstance, updateHeatmap]);
+
+  useEffect(() => {
+    if (!mapInstance || !heatmapInstance) return;
+
+    kakao.maps.event.addListener(mapInstance, 'center_changed', throttledUpdate);
+    kakao.maps.event.addListener(mapInstance, 'zoom_start', () => {
+      // zoom시 히트맵 숨김
+      heatmapInstance._renderer.canvas.style.opacity = '0';
+    });
+    kakao.maps.event.addListener(mapInstance, 'zoom_changed', () => {
+      heatmapInstance._renderer.canvas.style.opacity = '1';
+    });
+    kakao.maps.event.addListener(mapInstance, 'drag', throttledUpdate);
+
+    return () => {
+      kakao.maps.event.removeListener(mapInstance, 'center_changed', throttledUpdate);
+      kakao.maps.event.removeListener(mapInstance, 'zoom_start', throttledUpdate);
+      kakao.maps.event.removeListener(mapInstance, 'zoom_changed', throttledUpdate);
+      kakao.maps.event.removeListener(mapInstance, 'drag', throttledUpdate);
+
+      if (animationFrameRef.current) {
+        // 이미 예약된 rAF가 있다면 취소
+        cancelAnimationFrame(animationFrameRef.current);
+      }
+    };
+  }, [mapInstance, heatmapInstance, throttledUpdate]);
+};

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -75,3 +75,39 @@ export const numberTransfer = (number: number) => {
     return `${(number / 10000).toFixed(1)}M`;
   }
 };
+
+export function throttle<T extends (...args: any[]) => void>(fn: T, delay: number): T {
+  let lastCall = 0;
+
+  return function (...args: Parameters<T>) {
+    const now = Date.now();
+    if (now - lastCall >= delay) {
+      lastCall = now;
+      fn(...args);
+    }
+  } as T;
+}
+
+type HeatmapRenderCheckOptions = {
+  mapInstance: kakao.maps.Map | null;
+  heatmapInstance: any;
+  minZoomLevel?: number;
+};
+
+export const shouldRenderHeatmap = ({
+  mapInstance,
+  heatmapInstance,
+  minZoomLevel = 10,
+}: HeatmapRenderCheckOptions): boolean => {
+  if (!mapInstance || !heatmapInstance) return false;
+
+  const level = mapInstance.getLevel();
+  if (level > minZoomLevel) return false;
+
+  const canvas = heatmapInstance?._renderer?.canvas;
+  const shadowCanvas = heatmapInstance?._renderer?.shadowCanvas;
+
+  const isValid = (c?: HTMLCanvasElement | null) => !!c && c.width > 0 && c.height > 0;
+
+  return isValid(canvas) && isValid(shadowCanvas);
+};


### PR DESCRIPTION
## #️⃣연관된 이슈

#86 

## 📝작업 내용

- 기존의 updateHeatmap()과 드래그 줌 이벤트리스너 등록 삭제를 커스텀 훅으로 분리
- throttle 함수 구현
- 커스텀 훅 useThrottledHeatmapUpdate 내부에서 throttle을 적용하여 updateHeatmap을 호출하도록 구현
- 드래그를 빠르게 옮기거나 kakao map의 zoom level이 11 이상으로 줌아웃 되었을 때 발생하는 에러를 걸러내기 위해 shouldRenderHeatmap 함수 구현

### 스크린샷 (선택)

<img width="1088" alt="image" src="https://github.com/user-attachments/assets/8130441c-e2ec-4704-80fb-2e63abc015ec" />

throttle 적용 시 사용 법에 대한 이슈로 인한 시간이 많이 소요되었음 관련 내용은

#86 참고 요망

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.
