### PR TITLE
[FE] feat : 카카오 맵에 마커 클러스터러를 적용한다

### DIFF
--- a/src/components/KakaoMaps/KakaoMap.tsx
+++ b/src/components/KakaoMaps/KakaoMap.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
-import { Map, MapMarker, MapTypeControl, ZoomControl } from 'react-kakao-maps-sdk';
+import { Map, MapMarker, MapTypeControl, ZoomControl, MarkerClusterer } from 'react-kakao-maps-sdk';
 import { toast } from 'sonner';
 import MapErrorFallback from '@/components/KakaoMaps/MapErrorFallback';
 import MapLoadingFallback from '@/components/KakaoMaps/MapLoadingFallback';
@@ -237,6 +237,9 @@ const KakaoMap = ({ latitude, longitude, w, h, l, protests }: Props) => {
         onCreate={setMapInstance}
         onDragStart={handleDragStart}
         onDragEnd={handleDragEnd}
+        onZoomChanged={map => {
+          setCurrentLevel(map.getLevel());
+        }}
       >
         {currentLevel <= 8 && !isDragging && <NavigationRouteLines routeData={routeData} />}
         {currentPositionMarker && (
@@ -244,7 +247,64 @@ const KakaoMap = ({ latitude, longitude, w, h, l, protests }: Props) => {
             position={{ lat: currentPositionMarker.lat, lng: currentPositionMarker.long }}
           />
         )}
-        <ProtestMapMarkerList protests={protests} mapInstance={mapInstance} router={router} />
+        {currentLevel < 11 && (
+          <ProtestMapMarkerList protests={protests} mapInstance={mapInstance} router={router} />
+        )}
+        <MarkerClusterer
+          averageCenter={true}
+          minLevel={11}
+          calculator={[5, 10, 15]}
+          styles={[
+            {
+              width: '30px',
+              height: '30px',
+              background: 'rgba(0, 128, 255, 0.8)',
+              border: '2px solid white',
+              borderRadius: '50%',
+              color: '#fff',
+              fontWeight: 'bold',
+              fontSize: '13px',
+              textAlign: 'center',
+              lineHeight: '30px',
+            },
+            {
+              width: '40px',
+              height: '40px',
+              background: 'rgba(255, 165, 0, 0.8)',
+              border: '2px solid white',
+              color: '#fff',
+              fontWeight: 'bold',
+              fontSize: '14px',
+              textAlign: 'center',
+              lineHeight: '40px',
+            },
+            {
+              width: '50px',
+              height: '50px',
+              background: 'rgba(255, 69, 58, 0.8)',
+              border: '2px solid white',
+              borderRadius: '50%',
+              color: '#fff',
+              fontWeight: 'bold',
+              fontSize: '15px',
+              textAlign: 'center',
+              lineHeight: '50px',
+            },
+          ]}
+        >
+          {protests.map(protest => {
+            return (
+              <MapMarker
+                key={`map-maker-${protest.id}`}
+                position={{
+                  lat: protest.locations[0].latitude,
+                  lng: protest.locations[0].longitude,
+                }}
+                opacity={0}
+              />
+            );
+          })}
+        </MarkerClusterer>
         <MapTypeControl position={'TOPLEFT'} />
         <ZoomControl position={'LEFT'} />
       </Map>

--- a/src/components/KakaoMaps/KakaoMap.tsx
+++ b/src/components/KakaoMaps/KakaoMap.tsx
@@ -15,6 +15,7 @@ import useKakaoLoader from '@/hooks/useKakaoLoader';
 import { calculateRealDistanceOnePixel } from '@/lib/map';
 import { useThrottledHeatmapUpdate } from '@/hooks/useThrottledHeatmapUpdate';
 import { Protest } from '@/types/protest';
+import { clusterCalculator, clusterStyles } from '@/constants/clusterConfig';
 interface Props {
   latitude: number;
   longitude: number;
@@ -253,44 +254,8 @@ const KakaoMap = ({ latitude, longitude, w, h, l, protests }: Props) => {
         <MarkerClusterer
           averageCenter={true}
           minLevel={11}
-          calculator={[5, 10, 15]}
-          styles={[
-            {
-              width: '30px',
-              height: '30px',
-              background: 'rgba(0, 128, 255, 0.8)',
-              border: '2px solid white',
-              borderRadius: '50%',
-              color: '#fff',
-              fontWeight: 'bold',
-              fontSize: '13px',
-              textAlign: 'center',
-              lineHeight: '30px',
-            },
-            {
-              width: '40px',
-              height: '40px',
-              background: 'rgba(255, 165, 0, 0.8)',
-              border: '2px solid white',
-              color: '#fff',
-              fontWeight: 'bold',
-              fontSize: '14px',
-              textAlign: 'center',
-              lineHeight: '40px',
-            },
-            {
-              width: '50px',
-              height: '50px',
-              background: 'rgba(255, 69, 58, 0.8)',
-              border: '2px solid white',
-              borderRadius: '50%',
-              color: '#fff',
-              fontWeight: 'bold',
-              fontSize: '15px',
-              textAlign: 'center',
-              lineHeight: '50px',
-            },
-          ]}
+          calculator={clusterCalculator}
+          styles={clusterStyles}
         >
           {protests.map(protest => {
             return (

--- a/src/components/KakaoMaps/KakaoMap.tsx
+++ b/src/components/KakaoMaps/KakaoMap.tsx
@@ -15,7 +15,8 @@ import useKakaoLoader from '@/hooks/useKakaoLoader';
 import { calculateRealDistanceOnePixel } from '@/lib/map';
 import { useThrottledHeatmapUpdate } from '@/hooks/useThrottledHeatmapUpdate';
 import { Protest } from '@/types/protest';
-import { clusterCalculator, clusterStyles } from '@/constants/clusterConfig';
+import { CLUSTER_MIN_LEVEL, clusterCalculator, clusterStyles } from '@/constants/clusterConfig';
+import KakaoMapClusterer from '@/components/KakaoMaps/KakaoMapClusterer';
 interface Props {
   latitude: number;
   longitude: number;
@@ -248,28 +249,10 @@ const KakaoMap = ({ latitude, longitude, w, h, l, protests }: Props) => {
             position={{ lat: currentPositionMarker.lat, lng: currentPositionMarker.long }}
           />
         )}
-        {currentLevel < 11 && (
+        {currentLevel < CLUSTER_MIN_LEVEL && (
           <ProtestMapMarkerList protests={protests} mapInstance={mapInstance} router={router} />
         )}
-        <MarkerClusterer
-          averageCenter={true}
-          minLevel={11}
-          calculator={clusterCalculator}
-          styles={clusterStyles}
-        >
-          {protests.map(protest => {
-            return (
-              <MapMarker
-                key={`map-maker-${protest.id}`}
-                position={{
-                  lat: protest.locations[0].latitude,
-                  lng: protest.locations[0].longitude,
-                }}
-                opacity={0}
-              />
-            );
-          })}
-        </MarkerClusterer>
+        <KakaoMapClusterer protests={protests} />
         <MapTypeControl position={'TOPLEFT'} />
         <ZoomControl position={'LEFT'} />
       </Map>

--- a/src/components/KakaoMaps/KakaoMapClusterer.tsx
+++ b/src/components/KakaoMaps/KakaoMapClusterer.tsx
@@ -1,0 +1,35 @@
+import { MapMarker, MarkerClusterer } from 'react-kakao-maps-sdk';
+import { CLUSTER_MIN_LEVEL, clusterCalculator, clusterStyles } from '@/constants/clusterConfig';
+import { Protest } from '@/types/protest';
+
+interface Props {
+  protests: Protest[];
+}
+
+const KakaoMapClusterer = ({ protests }: Props) => {
+  return (
+    <MarkerClusterer
+      averageCenter={true}
+      // minLevel보다 줌 레벨 정도가 작을때만 클러스터러가 적용됩니다.
+      minLevel={CLUSTER_MIN_LEVEL}
+      calculator={clusterCalculator}
+      styles={clusterStyles}
+    >
+      {protests.map(protest => {
+        return (
+          // 시위 계산을 위한 마커입니다.
+          <MapMarker
+            key={`map-maker-${protest.id}`}
+            position={{
+              lat: protest.locations[0].latitude,
+              lng: protest.locations[0].longitude,
+            }}
+            opacity={0}
+          />
+        );
+      })}
+    </MarkerClusterer>
+  );
+};
+
+export default KakaoMapClusterer;

--- a/src/constants/clusterConfig.ts
+++ b/src/constants/clusterConfig.ts
@@ -36,3 +36,5 @@ export const clusterStyles = [
     lineHeight: '50px',
   },
 ];
+
+export const CLUSTER_MIN_LEVEL = 11;

--- a/src/constants/clusterConfig.ts
+++ b/src/constants/clusterConfig.ts
@@ -1,0 +1,38 @@
+export const clusterCalculator = [5, 10, 15];
+export const clusterStyles = [
+  {
+    width: '30px',
+    height: '30px',
+    background: 'rgba(0, 128, 255, 0.8)',
+    border: '2px solid white',
+    borderRadius: '50%',
+    color: '#fff',
+    fontWeight: 'bold',
+    fontSize: '13px',
+    textAlign: 'center',
+    lineHeight: '30px',
+  },
+  {
+    width: '40px',
+    height: '40px',
+    background: 'rgba(255, 165, 0, 0.8)',
+    border: '2px solid white',
+    color: '#fff',
+    fontWeight: 'bold',
+    fontSize: '14px',
+    textAlign: 'center',
+    lineHeight: '40px',
+  },
+  {
+    width: '50px',
+    height: '50px',
+    background: 'rgba(255, 69, 58, 0.8)',
+    border: '2px solid white',
+    borderRadius: '50%',
+    color: '#fff',
+    fontWeight: 'bold',
+    fontSize: '15px',
+    textAlign: 'center',
+    lineHeight: '50px',
+  },
+];


### PR DESCRIPTION
## #️⃣연관된 이슈

> 연관된 이슈를 작성해주세요.

## 📝작업 내용
> 사용자가 줌을 축소하면 시위 여러 개가 겹쳐 보이기 때문에 클러스터링을 적용하여 몇 개의 시위가 존재하는지를 자연스럽게 표현하고, 줌을 확대하면 시위별 응원수를 보여주는 방식으로 UX 개선을 진행했습니다.
### 클러스터 적용법
공문 내용
```tsx
<Map>
  <MarkerClusterer
    averageCenter={true} // 클러스터에 포함된 마커들의 평균 위치를 클러스터 마커 위치로 설정
    minLevel={10} // 클러스터 할 최소 지도 레벨
  >
    {protests.map((pos) => (
      <MapMarker
        key={`${pos.lat}-${pos.lng}`}
        position={{
          lat: pos.lat,
          lng: pos.lng,
        }}
      />
    ))}
  </MarkerClusterer>
</Map>

```

### 프로젝트에 적용

```tsx
<Map
  // ~~
>
  {currentLevel <= 8 && !isDragging && <NavigationRouteLines routeData={routeData} />}
  {currentPositionMarker && (
    <MapMarker
      position={{ lat: currentPositionMarker.lat, lng: currentPositionMarker.long }}
    />
  )}
  <MarkerClusterer averageCenter={true} minLevel={1}>
    <ProtestMapMarkerList protests={protests} mapInstance={mapInstance} router={router} />
  </MarkerClusterer>
  <MapTypeControl position={'TOPLEFT'} />
  <ZoomControl position={'LEFT'} />
</Map>  
```
![화면 기록 2025-04-22 오후 3 20 06 (1)](https://github.com/user-attachments/assets/14d26262-21a8-48e1-a7eb-8c8d7f9abd86)


>클러스터 동작함을 확인

### 그래서 프로젝트에 어떤 방식으로 적용하지

- 시위별 응원후는 합치면 안된다고 판단 사용자가 지도를 축소했을때는 아래 사진처럼 응원수를 보여주는건 의미가 없다고 판단하고 몇개의 시위가 존재하는지 클러스터를 통해서 보여주기로함

<img width="442" alt="스크린샷 2025-04-22 오후 3 07 21" src="https://github.com/user-attachments/assets/e3b724eb-4d1f-4f3a-96a7-7e1f7624a6a5" />
    
- 어떻게 적용할거냐 위 gif에서 보다시피 별다른 설정을 해주지 않았지만 마커를 알아서 통합하는걸 알 수 있음 특정 줌 레벨 이하에서는 마커와 응원수를 이상에서는 클러스터를 통한 해당 부근에 존재하는 시위 총 수를 제공

### 설계

- 예시 : 줌 레벨 8 이상에서는 시위 수를 이하에서는 마커를 보여주자~
    - 기존에 존재하던 줌 래벨을 활용해서 조건부 렌더링
    - 커스텀 오버레이는 있어야하니 안에 내용물만 제거하자

### 적용
<img width="303" alt="스크린샷 2025-04-22 오후 3 34 04" src="https://github.com/user-attachments/assets/16d6ba12-63d8-47d4-bd28-73f9e2321d42" />

### 안됨

- 코드 분석
    
    
<img width="381" alt="스크린샷 2025-04-22 오후 3 34 30" src="https://github.com/user-attachments/assets/cdfde1b0-d3f2-4df2-ad4f-34585d9d7092" />

줌 레벨 변화 인식 못함 조건부 

```tsx
<CustomOverlayMap>
 {zoomlevel >= 8 <마커내용물/> : null}
</CustomOverlayMap>
```

- 왜 setCurrentLevel 있던데 적용이 안되지? → 공식문서 → 코드 분석
   <img width="198" alt="스크린샷 2025-04-22 오후 3 37 00" src="https://github.com/user-attachments/assets/2f8b35d6-adfe-4af7-b502-95e003982728" />

공문 내용
    
  ```tsx
    <Map // 지도를 표시할 Container
    // ~~~
      onZoomChanged={(map) => {
        const level = map.getLevel()
        setResult(`현재 지도 레벨은 ${level} 입니다`)
      }}
    >
  ```
    
- 우리꺼에 없음 → 적용
    - 잘됨
    <img width="359" alt="스크린샷 2025-04-22 오후 3 39 19" src="https://github.com/user-attachments/assets/e5d2f64b-bf16-44b0-86a3-744ba33ac97d" />

- 적용은 되는데 자꾸 시위가 합쳐짐
    - 코드
        
        ```tsx
        const ProtestMapMarker = ({ protest, mapInstance, router, zoomLevel }: Props) => {
          return (
            <div>
              <CustomOverlayMap
              //~~~~
              >
                {zoomLevel >= 8 ? (
                  <div>
                    {effect && <div className='absolute bottom-10'>{EMOJI.FIRE}</div>}
                    <span className='text-xs pb-2 font-sans font-bold'>
                      {isLoading
                        ? `${EMOJI.FIRE}...`
                        : isError || !data
                        ? '0'
                        : numberTransfer(data.cheerCount)}
                    </span>
                  </div>
                ) : null}
              </CustomOverlayMap>
            </div>
          );
        };
        ```
        
        - 잘 모르겠음 → 생각 → 클러스터에 생각해보니 오버레이 통째로 합치는거 아닌가 그래서 자꾸 합처지나?
            - 다시 생각
                - 시위별 응원수는 합치면 안됨 → 클러스터 안에 있으면 안됨
                - 근데 클러스터가 계산을 하려면 커스텀 오버레이나 마커 컴포넌트가 있어야함
                - 깡통 마커 넣고 응원용 마커는 밖으로 빼자
    
### 적용기
    
```tsx
<MarkerClusterer averageCenter={true} minLevel={8}>
  <ProtestMapMarkerList
    protests={protests}
    mapInstance={mapInstance}
    router={router}
    zoomLevel={currentLevel}
  />
</MarkerClusterer>
```
    
- 생각해보니 줌 레벨 마커리스트에 넘겨주고 마커에 또 넘겨줬었는데 이렇게 분리할거면 안넘겨주고 마커 리스트 자체를 조건부 랜더링 하면 안됨?
    - 예상 질문을 위한 미리 대답 적기
        - 그럼 마커 안보이게 어떻게함?
            - opacity 적용하기
                 - 적용 전
                    <img width="39" alt="스크린샷 2025-04-22 오후 3 50 17" src="https://github.com/user-attachments/assets/6ceb1fd8-2760-4e2f-bb0d-6b1deae981e4" />
                 - 적용 후
                    <img width="30" alt="스크린샷 2025-04-22 오후 3 50 46" src="https://github.com/user-attachments/assets/ca953d49-bfa0-4793-be21-5f9598b6bc67" />

        - 마커는 어떻게 만든다는겨?
            - https://react-kakao-maps-sdk.jaeseokim.dev/docs/sample/library/basicClusterer

### 적용 후
![화면 기록 2025-04-22 오후 3 54 11](https://github.com/user-attachments/assets/6b760e9a-7c26-42f2-92c4-d1066e22549a)


- 숫자별 다른 UI 적용
    - https://react-kakao-maps-sdk.jaeseokim.dev/docs/sample/library/chickenClusterer
    
### 결과물
    
![화면 기록 2025-04-22 오후 4 05 08](https://github.com/user-attachments/assets/30bb178a-29bb-44ab-a541-33e2c03fbecd)


> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.
