### PR TITLE
[FE] Bug : 리팩토링 과정에서 누락 된 경로 검증 로직을 추가하고 수정한다

### DIFF
--- a/src/app/verified/page.tsx
+++ b/src/app/verified/page.tsx
@@ -20,7 +20,7 @@ export default function Page() {
   }, [router]);
 
   const handleGobackButton = () => {
-    sessionStorage.removeItem('fromValidRoute');
+    sessionStorage.setItem('fromValidRoute', 'false');
     router.back();
   };
 

--- a/src/app/verified/page.tsx
+++ b/src/app/verified/page.tsx
@@ -20,6 +20,7 @@ export default function Page() {
   }, [router]);
 
   const handleGobackButton = () => {
+    sessionStorage.removeItem('fromValidRoute');
     router.back();
   };
 

--- a/src/components/Verification/Verification.tsx
+++ b/src/components/Verification/Verification.tsx
@@ -36,10 +36,10 @@ export default function Verification({ paramId }: Props) {
   });
 
   const onVerificationClick = () => {
-    // if (!isMobile) {
-    //   alert('모바일에서만 인증이 가능합니다.');
-    //   return;
-    // }
+    if (!isMobile) {
+      alert('모바일에서만 인증이 가능합니다.');
+      return;
+    }
     if (!accessToken)
       window.location.replace(
         `${process.env.NEXT_PUBLIC_LOCAL_DEV_URL}/oauth2/authorization/kakao`,

--- a/src/components/Verification/Verification.tsx
+++ b/src/components/Verification/Verification.tsx
@@ -16,7 +16,6 @@ import {
 import ProtestActionButton from '@/components/Button/ProtestActionButton';
 import { getIsMobile, isDesktopOS } from '@/lib/utils';
 
-import { ProtestActionButton } from '@/components/Button';
 import { useUserInfoStore } from '@/store/useUserInfoStore';
 import { useLocationVerification } from '@/hooks/useLocationVerification';
 
@@ -37,10 +36,10 @@ export default function Verification({ paramId }: Props) {
   });
 
   const onVerificationClick = () => {
-    if (!isMobile) {
-      alert('모바일에서만 인증이 가능합니다.');
-      return;
-    }
+    // if (!isMobile) {
+    //   alert('모바일에서만 인증이 가능합니다.');
+    //   return;
+    // }
     if (!accessToken)
       window.location.replace(
         `${process.env.NEXT_PUBLIC_LOCAL_DEV_URL}/oauth2/authorization/kakao`,

--- a/src/hooks/useLocationVerification.ts
+++ b/src/hooks/useLocationVerification.ts
@@ -40,7 +40,7 @@ export const useLocationVerification = ({ agreed, curLocation, protestId }: Prop
       sessionStorage.setItem('fromValidRoute', 'true');
       router.replace(`/verified`);
     } else if (verificationResult?.success === false) {
-      sessionStorage.removeItem('fromValidRoute');
+      sessionStorage.setItem('fromValidRoute', 'false');
       router.replace(`/protest/${protestId}`);
     }
   }, [verificationResult]);


### PR DESCRIPTION
## #️⃣연관된 이슈

#105 

## 📝작업 내용

- 기존의 인증 로직이 useLocationVerification 훅으로 분리 되었으므로, 해당 인증 로직 또한 훅으로 옮겼다
- 기존의 코드에선 한 번 인증 후 sessionStorage에 fromVaildRoute가 true로 남아있었는데, 인증 실패 할 경우, 인증 완료 페이지 이동 후에 false로 초기화 하도록 하였다

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.
