### PR TITLE
[FE] Bug : 히트맵에서 11레벨 이상으로 줌 아웃 시 간헐적으로 발생하는 에러를 해결한다

### DIFF
--- a/src/hooks/useThrottledHeatmapUpdate.ts
+++ b/src/hooks/useThrottledHeatmapUpdate.ts
@@ -73,23 +73,33 @@ export const useThrottledHeatmapUpdate = ({
     }
   }, [heatmapInstance, mapInstance, updateHeatmap]);
 
+  const handleHideHeatmap = useCallback(() => {
+    if (!heatmapInstance) return;
+    heatmapInstance._renderer.canvas.style.opacity = '0';
+  }, [heatmapInstance]);
+
+  const handleShowHeatmap = useCallback(() => {
+    if (!mapInstance || !heatmapInstance) return;
+    const level = mapInstance.getLevel();
+    if (level > 10) {
+      heatmapInstance._renderer.canvas.style.opacity = '0';
+    } else {
+      heatmapInstance._renderer.canvas.style.opacity = '1';
+    }
+  }, [mapInstance, heatmapInstance]);
+
   useEffect(() => {
     if (!mapInstance || !heatmapInstance) return;
 
     kakao.maps.event.addListener(mapInstance, 'center_changed', throttledUpdate);
-    kakao.maps.event.addListener(mapInstance, 'zoom_start', () => {
-      // zoom시 히트맵 숨김
-      heatmapInstance._renderer.canvas.style.opacity = '0';
-    });
-    kakao.maps.event.addListener(mapInstance, 'zoom_changed', () => {
-      heatmapInstance._renderer.canvas.style.opacity = '1';
-    });
+    kakao.maps.event.addListener(mapInstance, 'zoom_start', handleHideHeatmap);
+    kakao.maps.event.addListener(mapInstance, 'zoom_changed', handleShowHeatmap);
     kakao.maps.event.addListener(mapInstance, 'drag', throttledUpdate);
 
     return () => {
       kakao.maps.event.removeListener(mapInstance, 'center_changed', throttledUpdate);
-      kakao.maps.event.removeListener(mapInstance, 'zoom_start', throttledUpdate);
-      kakao.maps.event.removeListener(mapInstance, 'zoom_changed', throttledUpdate);
+      kakao.maps.event.removeListener(mapInstance, 'zoom_start', handleHideHeatmap);
+      kakao.maps.event.removeListener(mapInstance, 'zoom_changed', handleShowHeatmap);
       kakao.maps.event.removeListener(mapInstance, 'drag', throttledUpdate);
 
       if (animationFrameRef.current) {
@@ -97,5 +107,5 @@ export const useThrottledHeatmapUpdate = ({
         cancelAnimationFrame(animationFrameRef.current);
       }
     };
-  }, [mapInstance, heatmapInstance, throttledUpdate]);
+  }, [mapInstance, heatmapInstance, throttledUpdate, handleHideHeatmap, handleShowHeatmap]); // eslint-disable-line react-hooks/exhaustive-deps
 };


### PR DESCRIPTION
## #️⃣연관된 이슈

#116 

## 📝작업 내용

> 작업한 내용을 작성해주세요.

- zoomstart와 zoom_changed 이벤트 핸들러가 잘못 관리되고 있던 상황을 별도의 핸들러를 등록하여 명확하게 관리하도록 변경
- heatmap의 opacity를 조절하는 핸들러는 잦은 리렌더를 겪기 때문에 useCallback을 사용하여 미연에 에러 방지
- showHeatmap 시 기존에 11레벨 이상부턴 setData()를 하지 않도록 하여 가려 놓았지만, zoom_changed 이벤트 이후는 무조건적으로 opacity를 1로 바꾸게 되어있었기 때문에 조건을 추가하여 수정 => 해당 부분이 에러의 주요 원인

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.
