### PR TITLE
[FE] refactor : 스크립트 중복 로드 문제를 해결하고 분석한다

### DIFF
--- a/src/api/protest.ts
+++ b/src/api/protest.ts
@@ -7,7 +7,6 @@ export const getProtestList = async (): Promise<Protest[]> => {
   const response = await fetch(`${SERVER_URL}/api/protest?date=${targetDate}`, {
     next: { revalidate: 10, tags: ['protestList'] },
   });
-  console.log('getProtestList', 'called');
   if (!response.ok) {
     throw new Error(response.statusText);
   }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -38,7 +38,6 @@ export default function RootLayout({
           src={`//dapi.kakao.com/v2/maps/sdk.js?appkey=${KAKAO_API_KEY}&autoload=false&libraries=clusterer`}
           strategy='beforeInteractive'
         />
-        <Script strategy='lazyOnload' src='https://unpkg.com/heatmap.js' />
         <TanStackProvider>
           <main>{children}</main>
           {modal}


### PR DESCRIPTION
## #️⃣연관된 이슈

> #111 

## 📝작업 내용
- 기존에 layout 컴포넌트에 히트맵을 호출하는 로직과 hook에서 또 히트맵을 호출하는 로직으로인해 개발도구에서 나오는 경고를 해결하였습니다.
- 처음에는 레이아웃의 스크립트를 놔두고 히트맵훅에서의 호출을 제거하였는데 현재는 스크립트를 제거하도록 하였습니다. 그 이유는 히드맵 스크립트 로드 함수때문입니다.
### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.
