### PR TITLE
bug/#114 : 재검증 로직에 페이지 캐시 초기화를 추가한다

### DIFF
--- a/src/api/protest.ts
+++ b/src/api/protest.ts
@@ -5,7 +5,7 @@ import { notFound } from 'next/navigation';
 
 export const getProtestList = async (): Promise<Protest[]> => {
   const response = await fetch(`${SERVER_URL}/api/protest?date=${targetDate}`, {
-    next: { revalidate: 10, tags: ['protestList'] },
+    next: { revalidate: 3600, tags: ['protestList'] },
   });
   if (!response.ok) {
     throw new Error(response.statusText);

--- a/src/app/(with-hamburger-button)/page.tsx
+++ b/src/app/(with-hamburger-button)/page.tsx
@@ -37,6 +37,8 @@ export const metadata: Metadata = {
   keywords,
 };
 
+export const revalidate = 3600;
+
 export default async function Home() {
   const protests = await getProtestList();
   const latitude = SEOUL_CENTER_LATITUDE;

--- a/src/app/v1/revalidate/protests/route.ts
+++ b/src/app/v1/revalidate/protests/route.ts
@@ -1,8 +1,9 @@
 import { NextResponse } from 'next/server';
-import { revalidateTag } from 'next/cache';
+import { revalidatePath, revalidateTag } from 'next/cache';
 
 export async function GET() {
   revalidateTag('protestList');
   revalidateTag('sitemap');
+  revalidatePath('/')
   return NextResponse.json({ success: true, message: 'Cache invalidated' });
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

#114 

## 📝작업 내용

- next의 캐싱에는 api 요청 캐싱과 페이지 html 캐싱이 존재한다
- 현재 build시 생성 된 페이지가 캐싱이 되어 있으며, 내부에서 props로 넘기는 api response 데이터가 바뀌더라도 이미 생성 된 페이지는 재 생성 되지 않는다(정적 페이지)

- 여기서 세 가지 선택지가 존재한다
  - 페이지를 동적 페이지로 만든다(비효율)
  - 페이지 캐시의 revalidate time을 준다(api 무효화 시간과 통일)
  - revalidatePath를 추가하여 해당페이지의 캐시를 무효화한다(원할 때 최신화 가능하도록)

- revalidatPath('/') 추가
- 재검증 시간 테스트용 10초 에서 다시 1시간으로 수정
- Home 페이지에 revalidate = 3600으로 1시간 갱신 적용

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.
