### PR TITLE
[FE] feat : 응원하기 실패시 로직을 강화한다.

### DIFF
--- a/src/components/KakaoMaps/KakaoMap.tsx
+++ b/src/components/KakaoMaps/KakaoMap.tsx
@@ -70,7 +70,7 @@ const KakaoMap = ({ protests }: Props) => {
           currentZoomLevel={currentZoomLevel}
           clusterMinLevel={CLUSTER_MIN_LEVEL}
           protests={protests}
-          mapInstance={mapInstance!}
+          mapInstance={mapInstance}
           router={router}
         />
         <KakaoMapClusterer protests={protests} />

--- a/src/components/Protest/ProtestCheerBadge.tsx
+++ b/src/components/Protest/ProtestCheerBadge.tsx
@@ -6,9 +6,9 @@ interface Props {
   protestId: string;
 }
 const ProtestCheerBadge = ({ protestId }: Props) => {
-  const { data, isLoading } = useProtestCheerCount({ protestId });
-  const { effect } = useCheerEffect(data);
-  if (!protestId || isLoading) return;
+  const { cheerCount, cheerCountIsLoading } = useProtestCheerCount({ protestId });
+  const { effect } = useCheerEffect(cheerCount);
+  if (!protestId || cheerCountIsLoading) return;
 
   return (
     <div className='flex flex-col justify-center items-center'>
@@ -18,7 +18,7 @@ const ProtestCheerBadge = ({ protestId }: Props) => {
             {EMOJI.FIRE}
           </div>
         )}
-        <div>{data?.cheerCount}</div>
+        <div>{cheerCount?.cheerCount}</div>
       </>
     </div>
   );

--- a/src/components/Protest/ProtestCheerBadge.tsx
+++ b/src/components/Protest/ProtestCheerBadge.tsx
@@ -6,9 +6,11 @@ interface Props {
   protestId: string;
 }
 const ProtestCheerBadge = ({ protestId }: Props) => {
-  const { cheerCount, cheerCountIsLoading } = useProtestCheerCount({ protestId });
+  const { cheerCount, cheerCountIsLoading, cheerCountIsError } = useProtestCheerCount({
+    protestId,
+  });
   const { effect } = useCheerEffect(cheerCount);
-  if (!protestId || cheerCountIsLoading) return;
+  if (!protestId || cheerCountIsError || cheerCountIsLoading) return null;
 
   return (
     <div className='flex flex-col justify-center items-center'>

--- a/src/components/Protest/ProtestDetailCheer.tsx
+++ b/src/components/Protest/ProtestDetailCheer.tsx
@@ -2,7 +2,6 @@
 
 import Image from 'next/image';
 import { EMOJI } from '@/constants/emojis';
-import { useConfetti } from '@/hooks/useConfetti';
 import { numberTransfer } from '@/lib/utils';
 import { useCheerEffect } from '@/hooks/useCheerEffect';
 import { useSendCheerMutation } from '@/hooks/useSendCheerMutation';
@@ -14,29 +13,25 @@ interface Props {
 }
 
 const ProtestDetailCheer = ({ protestId }: Props) => {
-  const { data, isLoading, isError } = useProtestCheerCount({ protestId });
-  const { effect } = useCheerEffect(data);
-  const { mutate } = useSendCheerMutation({ protestId });
-  const { getConfetti } = useConfetti();
-  const handleConffeti = () => {
-    getConfetti().addConfetti({
-      emojis: [EMOJI.FIRE, EMOJI.CHECK, EMOJI.HEART],
-      emojiSize: 80,
-      confettiNumber: 30,
-    });
+  const { cheerCount, cheerCountIsLoading, cheerCountIsError } = useProtestCheerCount({
+    protestId,
+  });
+  const { effect } = useCheerEffect(cheerCount);
+  const { cheerProtest, cheerError } = useSendCheerMutation({ protestId });
+
+  const handleCheerButtonClick = () => {
+    cheerProtest();
   };
+
   return (
     <div className='flex flex-col justify-center items-center  '>
       <ProtestActionButton
-        onClick={() => {
-          handleConffeti();
-          mutate();
-        }}
-        disabled={isLoading || isError || !data}
+        onClick={handleCheerButtonClick}
+        disabled={cheerCountIsLoading || cheerCountIsError || cheerError}
       >
-        {isLoading ? (
+        {cheerCountIsLoading ? (
           <div className='animate-spin'>{EMOJI.LOADDING}</div>
-        ) : isError || !data ? (
+        ) : cheerCountIsError ? (
           <div>{EMOJI.WARNING}</div>
         ) : (
           <>
@@ -45,7 +40,9 @@ const ProtestDetailCheer = ({ protestId }: Props) => {
             ) : (
               <Image src='/images/torch.png' alt='torch image' width={10} height={10} />
             )}
-            <span className='text-sm text-white'>{numberTransfer(data.cheerCount)} 응원하기</span>
+            <span className='text-sm text-white'>
+              {numberTransfer(cheerCount?.cheerCount ?? 'X')} 응원하기
+            </span>
           </>
         )}
       </ProtestActionButton>

--- a/src/components/Protest/ProtestList.tsx
+++ b/src/components/Protest/ProtestList.tsx
@@ -22,7 +22,7 @@ const ProtestList = async () => {
         <SheetHeader className='gap-1'>
           <SheetTitle className='hidden'>ProtestList</SheetTitle>
           <SheetDescription className='hidden'>ProtestList</SheetDescription>
-          {protests?.map((protest: Protest, idx: number) => <ProtestCard key={idx} {...protest} />)}
+          {protests?.map((protest: Protest) => <ProtestCard key={protest.id} {...protest} />)}
         </SheetHeader>
       </SheetContent>
     </Sheet>

--- a/src/components/Protest/ProtestMapMarker.tsx
+++ b/src/components/Protest/ProtestMapMarker.tsx
@@ -12,8 +12,10 @@ interface Props {
 }
 
 const ProtestMapMarker = ({ protest, mapInstance, router }: Props) => {
-  const { data, isLoading, isError } = useProtestCheerCount({ protestId: protest.id });
-  const { effect } = useCheerEffect(data);
+  const { cheerCount, cheerCountIsLoading, cheerCountIsError } = useProtestCheerCount({
+    protestId: protest.id,
+  });
+  const { effect } = useCheerEffect(cheerCount);
   const location = protest.locations[0];
 
   const onMarkerClick = (id: string, lat: number, long: number) => {
@@ -43,11 +45,11 @@ const ProtestMapMarker = ({ protest, mapInstance, router }: Props) => {
         >
           {effect && <div className='absolute bottom-10'>{EMOJI.FIRE}</div>}
           <span className='text-xs pb-2 font-sans font-bold'>
-            {isLoading
+            {cheerCountIsLoading
               ? `${EMOJI.FIRE}...`
-              : isError || !data
+              : cheerCountIsError || !cheerCount
                 ? '0'
-                : withSafe({ arg: data.cheerCount, callback: numberTransfer, fallback: 'X' })}
+                : withSafe({ arg: cheerCount.cheerCount, callback: numberTransfer, fallback: 'X' })}
           </span>
         </div>
       </CustomOverlayMap>

--- a/src/components/Protest/ProtestMapMarkerList.tsx
+++ b/src/components/Protest/ProtestMapMarkerList.tsx
@@ -6,7 +6,7 @@ interface ProtestMapMarkerListProps {
   currentZoomLevel: number;
   clusterMinLevel: number;
   protests: Protest[];
-  mapInstance: kakao.maps.Map;
+  mapInstance: kakao.maps.Map | null;
   router: AppRouterInstance;
 }
 
@@ -17,7 +17,7 @@ const ProtestMapMarkerList = ({
   mapInstance,
   router,
 }: ProtestMapMarkerListProps) => {
-  if (currentZoomLevel >= clusterMinLevel) return null;
+  if (currentZoomLevel >= clusterMinLevel || !mapInstance) return null;
   return (
     <>
       {protests.map(protest => (

--- a/src/hooks/useProtestCheerCount.ts
+++ b/src/hooks/useProtestCheerCount.ts
@@ -13,7 +13,7 @@ export const useProtestCheerCount = ({ protestId }: Props) => {
     queryKey: ['cheer', protestId],
     queryFn: () => getProtestCheerCount({ protestId }),
     refetchInterval: query => (query.state.error ? false : 3000),
-    enabled: !isDetail || (isDetail && currentProtestId === String(protestId)),
+    enabled: !isDetail || (isDetail && currentProtestId === protestId),
   });
   return {
     cheerCount: data,

--- a/src/hooks/useProtestCheerCount.ts
+++ b/src/hooks/useProtestCheerCount.ts
@@ -15,5 +15,5 @@ export const useProtestCheerCount = ({ protestId }: Props) => {
     refetchInterval: query => (query.state.error ? false : 3000),
     enabled: !isDetail || (isDetail && currentProtestId === String(protestId)),
   });
-  return { data: data, isLoading, isError };
+  return { cheerCount: data, cheerCountIsLoading: isLoading, cheerCountIsError: isError };
 };

--- a/src/hooks/useProtestCheerCount.ts
+++ b/src/hooks/useProtestCheerCount.ts
@@ -15,5 +15,9 @@ export const useProtestCheerCount = ({ protestId }: Props) => {
     refetchInterval: query => (query.state.error ? false : 3000),
     enabled: !isDetail || (isDetail && currentProtestId === String(protestId)),
   });
-  return { cheerCount: data, cheerCountIsLoading: isLoading, cheerCountIsError: isError };
+  return {
+    cheerCount: data,
+    cheerCountIsLoading: isLoading,
+    cheerCountIsError: isError,
+  };
 };

--- a/src/hooks/useSendCheerMutation.ts
+++ b/src/hooks/useSendCheerMutation.ts
@@ -1,4 +1,6 @@
 import { postProtestCheer } from '@/api/cheer';
+import { EMOJI } from '@/constants/emojis';
+import { useConfetti } from '@/hooks/useConfetti';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 interface Props {
@@ -7,11 +9,20 @@ interface Props {
 
 export const useSendCheerMutation = ({ protestId }: Props) => {
   const queryClient = useQueryClient();
-
-  return useMutation({
+  const { getConfetti } = useConfetti();
+  const { mutate, isError, isSuccess } = useMutation({
     mutationFn: () => postProtestCheer({ protestId }),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['cheer', protestId] });
+      getConfetti().addConfetti({
+        emojis: [EMOJI.FIRE, EMOJI.CHECK, EMOJI.HEART],
+        emojiSize: 80,
+        confettiNumber: 30,
+      });
+    },
+    onError: () => {
+      alert('응원하기가 실패했습니다.');
     },
   });
+  return { cheerProtest: mutate, cheerError: isError, cheerSuccess: isSuccess };
 };


### PR DESCRIPTION
## #️⃣연관된 이슈

> 연관된 이슈를 작성해주세요.

## 📝작업 내용
### 응원하기 실패시 로직 강화
- 응원하기 성공 여부를 고려하지 않고 무작정 발생하던 confetti 효과를 응원하기 성공시에만 발생하게 수정하였습니다.
- 응원하기 리액트쿼리 관련 변수명을 보다 직관적으로 변경하였습니다.
- 응원하기 버튼 클릭시의 동작을 별도의 함수로 분리하였습니다.
- 응원하기 실패시 처리에대해 많은 고민을 하였습니다.
    - 응원하기 실패시 어떤 UI를 제공할지 -> 응원하기 실패시에도 응원하기 버튼 비활성화
    - 응원하기 실패시 alert창을 통한 에러 문구 제공
- ProtestDetailCheer 컴포넌트에 집중되어있던 책임을 분리하였습니다.
    - confetti를 응원하기 훅으로 분리하였습니다.

### 불필요한 타입 단언을 제거한다.
- 마커 리스트에 타입 단언을 해둔 맵 인스턴스 타입 로직을 내부로 넣었습니다.
### 이전 리팩토링 변경 누락문제로 인한 훅 함수명 변경
- 이전 커밋에서 리팩토링중 누락된 함수명에따른 코드를 변경한다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.
