### PR TITLE
[FE] bug : 하루가 지나면 데이터 갱신이 작동하지 않는 문제를 해결한다

### DIFF
--- a/src/api/protest.ts
+++ b/src/api/protest.ts
@@ -1,9 +1,10 @@
-import { SERVER_URL, targetDate } from '@/lib/utils';
+import { SERVER_URL, getTargetDate } from '@/lib/utils';
 import type { ApiResponse } from '@/types/api';
 import type { Protest } from '@/types/protest';
 import { notFound } from 'next/navigation';
 
 export const getProtestList = async (): Promise<Protest[]> => {
+  const targetDate = getTargetDate();
   const response = await fetch(`${SERVER_URL}/api/protest?date=${targetDate}`, {
     next: { revalidate: 3600, tags: ['protestList'] },
   });

--- a/src/api/verification.ts
+++ b/src/api/verification.ts
@@ -1,4 +1,4 @@
-import { SERVER_URL, targetDate } from '@/lib/utils';
+import { SERVER_URL, getTargetDate } from '@/lib/utils';
 import type { ApiResponse } from '@/types/api';
 import type { VerificationNumber } from '@/types/protest';
 import { notFound } from 'next/navigation';
@@ -10,6 +10,7 @@ interface getVerificationNumberRequest {
 export const getVerificationNumber = async ({
   protestId,
 }: getVerificationNumberRequest): Promise<VerificationNumber> => {
+  const targetDate = getTargetDate();
   const response = await fetch(
     `${SERVER_URL}/api/protest/verifications?protestId=${protestId}&date=${targetDate}`,
     {

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -2,8 +2,14 @@ import { clsx, type ClassValue } from 'clsx';
 import { twMerge } from 'tailwind-merge';
 
 export const SERVER_URL = process.env.NEXT_PUBLIC_SERVER_DEV_URL;
-export const targetDate =
-  process.env.NODE_ENV === 'development' ? '2025-03-15' : new Date().toISOString().split('T')[0];
+
+export const getTargetDate = () => {
+  if (process.env.NODE_ENV === 'development') {
+    return '2025-03-15';
+  } else {
+    return new Date().toISOString().split('T')[0];
+  }
+};
 
 export const cn = (...inputs: ClassValue[]) => {
   return twMerge(clsx(inputs));


### PR DESCRIPTION
## #️⃣연관된 이슈

#132 

## 📝작업 내용

키워드는 모듈 캐싱이다

- 기존에  targetDate를 사용하여 해당 날짜의 시위 데이터를 fetch로 요청하여 사용하고 있었는데, 해당 경우 next 서버 실행 시 의 날짜로 고정 되어 날짜가 변경되더라도 바뀌지 않기 때문에 빌드 시의 날짜로 계속 데이터 요청을 하여 새로운 데이터를 볼 수 없는 것이였다.

### 모듈 캐싱

- js의 경우 모듈을 기본적으로 한 번만 로드하고 이후는 캐싱 된 결과를 활용하여 실행을 하게 된다.  
  이는 매 호출 시 마다 모듈을 실행시킬 경우 메모리 사용이 불필요하게 늘어날 수 있기 때문에 기본적으로 적용되는 개념이다.

### 기존 상황

![image](https://github.com/user-attachments/assets/17ad7b2c-4bc9-4313-8df8-8f97756e5ad2)  
- 기존의 이 방식으로는 모듈 최상단에 선언되었기 때문에 next 서버가 처음 실행 될 때, 한 번 실행되며 이 결과가 캐싱되어 이후 재사용되게 된다(모듈 캐싱) => 하루가 지나도 날짜가 변하지 않으니 데이터 또한 변하지 않는다(실제로 빌드 한 날짜의 데이터만 계속 보여지고 있는 상황이였음)

### 해결 방법

![image](https://github.com/user-attachments/assets/f0e21124-2e60-4751-a5e2-7bf678ec8668)  
- 변수로 선언되었던 것을 함수로 변경 한 뒤 fetch 함수 내부에서 함수를 호출하여 얻은 결과를 사용하도록 변경하였다
- 이 경우 모듈이 import 될 때 바로 실행되는 게 아니라 함수가 정의만 된다(추후 해당 함수를 호출 할 경우 실행된다)

## 결론

- 또 결국에는 기본적인 언어/프레임워크 의 동작 원리에 대해 이해가 부족했기 때문에 버그 해결에 어려움을 겪었다
- 기본에 충실하자!

[참고하면 이해에 도움이 될 자료](https://velog.io/@ssoon-m/js-%EB%AA%A8%EB%93%88-%EC%8A%A4%EC%BD%94%ED%94%84-%EC%BA%90%EC%8B%B1%EC%97%90-%EB%8C%80%ED%95%B4-%EC%95%8C%EA%B3%A0-%EA%B3%84%EC%8B%A0%EA%B0%80%EC%9A%94)

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.
