### PR TITLE
[FE] fix : 브라우저의 SRI 차단 문제를 해결한다

### DIFF
--- a/src/hooks/useHeatMap.ts
+++ b/src/hooks/useHeatMap.ts
@@ -45,8 +45,8 @@ export const useHeatMap = ({ mapInstance, protests }: Props) => {
     if (!mapInstance || heatmapInstance) return
 
     const script = document.createElement('script')
-    script.src = 'https://unpkg.com/heatmap.js'
-    script.integrity = process.env.NEXT_PUBLIC_HEATMAP_SHI || ''
+    script.src = 'https://unpkg.com/heatmap.js@2.0.5/build/heatmap.min.js'
+    script.integrity = process.env.NEXT_PUBLIC_HEATMAP_SRI || ''
     script.crossOrigin = 'anonymous'
     script.onload = () => {
       const container = document.getElementById('map')


### PR DESCRIPTION
## 연관된 이슈

> 없음 (브라우저 보안 차단 및 스크립트 무결성 관련 직접 수정)

## 작업 내용

### 문제 배경

기존에 heatmap.js 외부 스크립트를 로드할 때 다음과 같은 코드로 처리하고 있었습니다:

```ts
script.src = 'https://unpkg.com/heatmap.js'
script.integrity = process.env.NEXT_PUBLIC_HEATMAP_SRI || ''
script.crossOrigin = 'anonymous'
```

그러나 해당 URL은 최신 버전(`latest`)으로 리디렉션되며, 이로 인해 브라우저는 다음과 같은 오류를 발생시킵니다:

```
Failed to find a valid digest in the 'integrity' attribute for resource 'https://unpkg.com/heatmap.js' with computed SHA-384 integrity '...'. The resource has been blocked.
```

이는 integrity 해시가 리디렉션된 실제 파일과 불일치하기 때문에 발생합니다.

### 주요 원인

* `unpkg.com/heatmap.js`는 명확한 버전 없이 접근 시 최신 릴리스를 반환하며, SRI 해시가 지속적으로 바뀜
* 무결성 검증을 위해서는 **정적 파일 경로**와 **고정된 해시**가 반드시 필요함

### 해결 방법

* heatmap.js를 버전 및 파일 경로까지 명시적으로 지정: `https://unpkg.com/heatmap.js@2.0.5/build/heatmap.min.js`
* 해당 파일 기준으로 SRI 해시를 다시 생성하여 환경 변수에 주입함

```ts
const script = document.createElement('script');
script.src = 'https://unpkg.com/heatmap.js@2.0.5/build/heatmap.min.js';
script.integrity = process.env.NEXT_PUBLIC_HEATMAP_SRI || '';
script.crossOrigin = 'anonymous';
```

### 적용된 해시 (.env.local)

```
NEXT_PUBLIC_HEATMAP_SRI=sha384-BlRWQS67hrnZlggSB+aRUTIWyxdjmsWxRnta6UvociBjKrx7/QuODVy7TJ0ov3Pi
```

## 리뷰 요청 사항

* 리디렉션 없이 고정된 버전 사용 방식이 적절한지
* SRI 적용 방식과 환경 변수 처리 흐름에 문제가 없는지 확인 부탁드립니다.

## 스크린샷

> 없음 (스크립트 차단 문제 해결 목적 PR)
